### PR TITLE
feat: add grpc options for creating GreenfieldClient

### DIFF
--- a/client/chain/gnfd_client.go
+++ b/client/chain/gnfd_client.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	_ "encoding/json"
+
 	"github.com/bnb-chain/greenfield-go-sdk/keys"
 	"github.com/bnb-chain/greenfield-go-sdk/types"
 	bridgetypes "github.com/bnb-chain/greenfield/x/bridge/types"
@@ -24,7 +25,6 @@ import (
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/credentials/insecure"
 )
 
 type AuthQueryClient = authtypes.QueryClient
@@ -70,10 +70,10 @@ type GreenfieldClient struct {
 	codec      *codec.ProtoCodec
 }
 
-func grpcConn(addr string) *grpc.ClientConn {
+func grpcConn(addr string, opts ...grpc.DialOption) *grpc.ClientConn {
 	conn, err := grpc.Dial(
 		addr,
-		grpc.WithTransportCredentials(insecure.NewCredentials()),
+		opts...,
 	)
 	if err != nil {
 		panic(err)
@@ -81,8 +81,8 @@ func grpcConn(addr string) *grpc.ClientConn {
 	return conn
 }
 
-func NewGreenfieldClient(grpcAddr, chainId string) GreenfieldClient {
-	conn := grpcConn(grpcAddr)
+func NewGreenfieldClient(grpcAddr, chainId string, opts ...grpc.DialOption) GreenfieldClient {
+	conn := grpcConn(grpcAddr, opts...)
 	cdc := types.Cdc()
 	return GreenfieldClient{
 		authtypes.NewQueryClient(conn),
@@ -109,8 +109,8 @@ func NewGreenfieldClient(grpcAddr, chainId string) GreenfieldClient {
 	}
 }
 
-func NewGreenfieldClientWithKeyManager(grpcAddr, chainId string, keyManager keys.KeyManager) GreenfieldClient {
-	gnfdClient := NewGreenfieldClient(grpcAddr, chainId)
+func NewGreenfieldClientWithKeyManager(grpcAddr, chainId string, keyManager keys.KeyManager, opts ...grpc.DialOption) GreenfieldClient {
+	gnfdClient := NewGreenfieldClient(grpcAddr, chainId, opts...)
 	gnfdClient.keyManager = keyManager
 	return gnfdClient
 }

--- a/client/chain/tx_test.go
+++ b/client/chain/tx_test.go
@@ -1,6 +1,8 @@
 package chain
 
 import (
+	"testing"
+
 	"github.com/bnb-chain/greenfield-go-sdk/client/test"
 	"github.com/bnb-chain/greenfield-go-sdk/keys"
 	"github.com/bnb-chain/greenfield-go-sdk/types"
@@ -8,13 +10,15 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestSendTokenSucceedWithSimulatedGas(t *testing.T) {
 	km, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
 	assert.NoError(t, err)
-	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km)
+	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
 	assert.NoError(t, err)
 	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin("bnb", 12)))
@@ -27,7 +31,8 @@ func TestSendTokenSucceedWithSimulatedGas(t *testing.T) {
 func TestSendTokenWithTxOptionSucceed(t *testing.T) {
 	km, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
 	assert.NoError(t, err)
-	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km)
+	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
 	assert.NoError(t, err)
 	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin("bnb", 100)))
@@ -49,7 +54,8 @@ func TestSendTokenWithTxOptionSucceed(t *testing.T) {
 func TestSimulateTx(t *testing.T) {
 	km, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
 	assert.NoError(t, err)
-	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km)
+	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km,
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
 	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
 	assert.NoError(t, err)
 	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin("bnb", 100)))


### PR DESCRIPTION
### Description

add grpc options for creating GreenfieldClient

### Rationale

grpc connection supported many options to setup, need to expose them for the user.

### Example

```go
gnfdCli := NewGreenfieldClient(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, 
		grpc.WithTransportCredentials(insecure.NewCredentials()))
```

### Changes

Notable changes:
* greenfield client