### PR TITLE
refactor: rewrite the NewGreenfieldClient function by option pattern

### DIFF
--- a/client/chain/gnfd_client_option.go
+++ b/client/chain/gnfd_client_option.go
@@ -1,0 +1,33 @@
+package chain
+
+import (
+	"github.com/bnb-chain/greenfield-go-sdk/keys"
+	"google.golang.org/grpc"
+)
+
+// GreenfieldClientOption configures how we set up the greenfield client.
+type GreenfieldClientOption interface {
+	Apply(*GreenfieldClient)
+}
+
+// GreenfieldClientOptionFunc defines an applied function for setting the greenfield client.
+type GreenfieldClientOptionFunc func(*GreenfieldClient)
+
+// Apply set up the option field to the client instance.
+func (f GreenfieldClientOptionFunc) Apply(client *GreenfieldClient) {
+	f(client)
+}
+
+// WithKeyManager returns a GreenfieldClientOption which configures a client key manager option.
+func WithKeyManager(km keys.KeyManager) GreenfieldClientOption {
+	return GreenfieldClientOptionFunc(func(client *GreenfieldClient) {
+		client.keyManager = km
+	})
+}
+
+// WithGrpcDialOption returns a GreenfieldClientOption which configures a grpc client connection options.
+func WithGrpcDialOption(opts ...grpc.DialOption) GreenfieldClientOption {
+	return GreenfieldClientOptionFunc(func(client *GreenfieldClient) {
+		client.grpcDialOption = opts
+	})
+}

--- a/client/chain/tx_test.go
+++ b/client/chain/tx_test.go
@@ -1,6 +1,8 @@
 package chain
 
 import (
+	"testing"
+
 	"github.com/bnb-chain/greenfield-go-sdk/client/test"
 	"github.com/bnb-chain/greenfield-go-sdk/keys"
 	"github.com/bnb-chain/greenfield-go-sdk/types"
@@ -8,16 +10,19 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestSendTokenSucceedWithSimulatedGas(t *testing.T) {
 	km, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
 	assert.NoError(t, err)
-	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km)
+	gnfdCli := NewGreenfieldClient(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID,
+		WithKeyManager(km),
+		WithGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
 	assert.NoError(t, err)
-	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin("bnb", 12)))
+	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin(test.TEST_TOKEN_NAME, 12)))
 	response, err := gnfdCli.BroadcastTx([]sdk.Msg{transfer}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, uint32(0), response.TxResponse.Code)
@@ -27,17 +32,20 @@ func TestSendTokenSucceedWithSimulatedGas(t *testing.T) {
 func TestSendTokenWithTxOptionSucceed(t *testing.T) {
 	km, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
 	assert.NoError(t, err)
-	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km)
+	gnfdCli := NewGreenfieldClient(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID,
+		WithKeyManager(km),
+		WithGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
 	assert.NoError(t, err)
-	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin("bnb", 100)))
+	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin(test.TEST_TOKEN_NAME, 100)))
 	payerAddr, err := sdk.AccAddressFromHexUnsafe(km.GetAddr().String())
-	mode := tx.BroadcastMode_BROADCAST_MODE_ASYNC
+	assert.NoError(t, err)
+	mode := tx.BroadcastMode_BROADCAST_MODE_BLOCK
 	txOpt := &types.TxOption{
 		Mode:      &mode,
 		GasLimit:  123456,
 		Memo:      "test",
-		FeeAmount: sdk.Coins{{"bnb", sdk.NewInt(1)}},
+		FeeAmount: sdk.NewCoins(sdk.NewInt64Coin(test.TEST_TOKEN_NAME, 1)),
 		FeePayer:  payerAddr,
 	}
 	response, err := gnfdCli.BroadcastTx([]sdk.Msg{transfer}, txOpt)
@@ -49,10 +57,12 @@ func TestSendTokenWithTxOptionSucceed(t *testing.T) {
 func TestSimulateTx(t *testing.T) {
 	km, err := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
 	assert.NoError(t, err)
-	gnfdCli := NewGreenfieldClientWithKeyManager(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID, km)
+	gnfdCli := NewGreenfieldClient(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID,
+		WithKeyManager(km),
+		WithGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
 	to, err := sdk.AccAddressFromHexUnsafe(test.TEST_ADDR)
 	assert.NoError(t, err)
-	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin("bnb", 100)))
+	transfer := banktypes.NewMsgSend(km.GetAddr(), to, sdk.NewCoins(sdk.NewInt64Coin(test.TEST_TOKEN_NAME, 100)))
 	simulateRes, err := gnfdCli.SimulateTx([]sdk.Msg{transfer}, nil)
 	assert.NoError(t, err)
 	t.Log(simulateRes.GasInfo.String())

--- a/client/test/config.go
+++ b/client/test/config.go
@@ -10,4 +10,5 @@ const (
 	TEST_GRPC_ADDR   = "localhost:9090"
 	TEST_RPC_ADDR    = "http://0.0.0.0:26750"
 	TEST_CHAIN_ID    = "greenfield_9000-121"
+	TEST_TOKEN_NAME  = "bnb"
 )


### PR DESCRIPTION
### Description

Rewrite the NewGreenfieldClient function by option pattern. 
The code can be more flexibly extended

### Rationale

rewrite by the options pattern.

### Example

```go
km, _ := keys.NewPrivateKeyManager(test.TEST_PRIVATE_KEY)
gnfdCli := NewGreenfieldClient(test.TEST_GRPC_ADDR, test.TEST_CHAIN_ID,
	WithKeyManager(km),
	WithGrpcDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())))
```

### Changes

Notable changes:
* new function of GreenfieldClient