### PR TITLE
feat: add createfolder api

### DIFF
--- a/client/api_object.go
+++ b/client/api_object.go
@@ -60,7 +60,8 @@ type Object interface {
 	// ComputeHashRoots compute the integrity hash, content size and the redundancy type of the file
 	ComputeHashRoots(reader io.Reader) ([][]byte, int64, storageTypes.RedundancyType, error)
 
-	// CreateFolder creates an empty object ending with a forward slash (/) character
+	// CreateFolder creates an empty object used as folder.
+	// objectName must ending with a forward slash (/) character
 	CreateFolder(ctx context.Context, bucketName, objectName string, opts types.CreateObjectOptions) (string, error)
 }
 
@@ -557,8 +558,12 @@ func (c *client) GetCreateObjectApproval(ctx context.Context, createObjectMsg *s
 	return &signedMsg, nil
 }
 
-// CreateFolder send createObject txn to greenfield chain
+// CreateFolder send create empty object txn to greenfield chain
 func (c *client) CreateFolder(ctx context.Context, bucketName, objectName string, opts types.CreateObjectOptions) (string, error) {
+	if !strings.HasSuffix(objectName, "/") {
+		return "", errors.New("failed to create folder. Folder names must end with a forward slash (/) character")
+	}
+
 	reader := bytes.NewReader([]byte(``))
 	txHash, err := c.CreateObject(ctx, bucketName, objectName, reader, opts)
 	return txHash, err

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -58,6 +59,9 @@ type Object interface {
 	ListObjects(ctx context.Context, bucketName string, opts types.ListObjectsOptions) (types.ListObjectsResult, error)
 	// ComputeHashRoots compute the integrity hash, content size and the redundancy type of the file
 	ComputeHashRoots(reader io.Reader) ([][]byte, int64, storageTypes.RedundancyType, error)
+
+	// CreateFolder creates an empty object ending with slash
+	CreateFolder(ctx context.Context, bucketName, objectName string, opts types.CreateObjectOptions) (string, error)
 }
 
 // GetRedundancyParams query and return the data shards, parity shards and segment size of redundancy
@@ -551,4 +555,11 @@ func (c *client) GetCreateObjectApproval(ctx context.Context, createObjectMsg *s
 	storageTypes.ModuleCdc.MustUnmarshalJSON(signedMsgBytes, &signedMsg)
 
 	return &signedMsg, nil
+}
+
+// CreateFolder send createObject txn to greenfield chain
+func (c *client) CreateFolder(ctx context.Context, bucketName, objectName string, opts types.CreateObjectOptions) (string, error) {
+	reader := bytes.NewReader([]byte(``))
+	txHash, err := c.CreateObject(ctx, bucketName, objectName, reader, opts)
+	return txHash, err
 }

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -60,7 +60,7 @@ type Object interface {
 	// ComputeHashRoots compute the integrity hash, content size and the redundancy type of the file
 	ComputeHashRoots(reader io.Reader) ([][]byte, int64, storageTypes.RedundancyType, error)
 
-	// CreateFolder creates an empty object ending with slash
+	// CreateFolder creates an empty object ending with a forward slash (/) character
 	CreateFolder(ctx context.Context, bucketName, objectName string, opts types.CreateObjectOptions) (string, error)
 }
 


### PR DESCRIPTION
### Description

Add CreateFolder API

### Example

```go
cli, err := client.New(ChainID, Endpoint, client.Option{
DefaultAccount: account,
GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials())},
)
assert.NoError(t, err)
ctx := context.Background()

var opts types.CreateObjectOptions
txHash, err := cli.CreateFolder(ctx, "bucket name", "/dir/subdir/", opts )
assert.NoError(t, err)
t.Logf("Acc: %s", txHash)
waitForTx, err := cli.WaitForTx(ctx, txHash)
assert.NoError(t, err)
t.Logf("Wair for tx: %s", waitForTx.String())
```

### Changes

Notable changes:
* add create folder api
* ...