### PR TITLE
feat: add payment client and sp functions

### DIFF
--- a/client/api_account.go
+++ b/client/api_account.go
@@ -20,7 +20,7 @@ type Account interface {
 	GetModuleAccountByName(ctx context.Context, name string) (authTypes.ModuleAccountI, error)
 	GetPaymentAccountsByOwner(ctx context.Context, owner string) ([]*paymentTypes.PaymentAccount, error)
 
-	CreatePaymentAccount(ctx context.Context, address string, txOption *gnfdSdkTypes.TxOption) (string, error)
+	CreatePaymentAccount(ctx context.Context, address string, txOption gnfdSdkTypes.TxOption) (string, error)
 	Transfer(ctx context.Context, toAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error)
 	MultiTransfer(ctx context.Context, details []types.TransferDetail, txOption gnfdSdkTypes.TxOption) (string, error)
 }
@@ -53,13 +53,13 @@ func (c *client) GetAccount(ctx context.Context, address string) (authTypes.Acco
 
 // CreatePaymentAccount creates a new payment account on the blockchain using the provided address.
 // It returns a TxResponse containing information about the transaction, or an error if the transaction failed.
-func (c *client) CreatePaymentAccount(ctx context.Context, address string, txOption *gnfdSdkTypes.TxOption) (string, error) {
+func (c *client) CreatePaymentAccount(ctx context.Context, address string, txOption gnfdSdkTypes.TxOption) (string, error) {
 	accAddress, err := sdk.AccAddressFromHexUnsafe(address)
 	if err != nil {
 		return "", err
 	}
 	msgCreatePaymentAccount := paymentTypes.NewMsgCreatePaymentAccount(accAddress.String())
-	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgCreatePaymentAccount}, txOption)
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgCreatePaymentAccount}, &txOption)
 	if err != nil {
 		return "", err
 	}

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -33,6 +33,7 @@ type Client interface {
 	Group
 	Challenge
 	Account
+	Payment
 	SP
 	Proposal
 

--- a/client/api_payment.go
+++ b/client/api_payment.go
@@ -1,0 +1,84 @@
+package client
+
+import (
+	"context"
+	"cosmossdk.io/math"
+	gnfdSdkTypes "github.com/bnb-chain/greenfield/sdk/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	paymentTypes "github.com/bnb-chain/greenfield/x/payment/types"
+)
+
+type Payment interface {
+	GetStreamRecord(ctx context.Context, streamAddress string) (*paymentTypes.StreamRecord, error)
+
+	Deposit(ctx context.Context, toAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error)
+	Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error)
+	DisableRefund(ctx context.Context, paymentAddress string, txOption *gnfdSdkTypes.TxOption) (string, error)
+}
+
+// GetStreamRecord retrieves stream record information for a given stream address.
+func (c *client) GetStreamRecord(ctx context.Context, streamAddress string) (*paymentTypes.StreamRecord, error) {
+	accAddress, err := sdk.AccAddressFromHexUnsafe(streamAddress)
+	if err != nil {
+		return nil, err
+	}
+	pa, err := c.chainClient.StreamRecord(ctx, &paymentTypes.QueryGetStreamRecordRequest{Account: accAddress.String()})
+	if err != nil {
+		return nil, err
+	}
+	return &pa.StreamRecord, nil
+}
+
+// Deposit deposits BNB to a stream account.
+func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error) {
+	accAddress, err := sdk.AccAddressFromHexUnsafe(toAddress)
+	if err != nil {
+		return "", err
+	}
+	msgDeposit := &paymentTypes.MsgDeposit{
+		Creator: c.MustGetDefaultAccount().GetAddress().String(),
+		To:      accAddress.String(),
+		Amount:  amount,
+	}
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDeposit}, &txOption)
+	if err != nil {
+		return "", err
+	}
+	return tx.TxResponse.TxHash, nil
+}
+
+// Withdraw withdraws BNB from a stream account.
+func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error) {
+	accAddress, err := sdk.AccAddressFromHexUnsafe(fromAddress)
+	if err != nil {
+		return "", err
+	}
+	msgWithdraw := &paymentTypes.MsgWithdraw{
+		Creator: c.MustGetDefaultAccount().GetAddress().String(),
+		From:    accAddress.String(),
+		Amount:  amount,
+	}
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgWithdraw}, &txOption)
+	if err != nil {
+		return "", err
+	}
+	return tx.TxResponse.TxHash, nil
+}
+
+// DisableRefund disables refund for a stream account.
+func (c *client) DisableRefund(ctx context.Context, paymentAddress string, txOption gnfdSdkTypes.TxOption) (string, error) {
+	accAddress, err := sdk.AccAddressFromHexUnsafe(paymentAddress)
+	if err != nil {
+		return "", err
+	}
+	msgDisableRefund := &paymentTypes.MsgDisableRefund{
+		Owner: c.MustGetDefaultAccount().GetAddress().String(),
+		Addr:  accAddress.String(),
+	}
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDisableRefund}, &txOption)
+	if err != nil {
+		return "", err
+	}
+	return tx.TxResponse.TxHash, nil
+}

--- a/client/api_payment.go
+++ b/client/api_payment.go
@@ -31,7 +31,7 @@ func (c *client) GetStreamRecord(ctx context.Context, streamAddress string) (*pa
 }
 
 // Deposit deposits BNB to a stream account.
-func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error) {
+func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error) {
 	accAddress, err := sdk.AccAddressFromHexUnsafe(toAddress)
 	if err != nil {
 		return "", err
@@ -41,7 +41,7 @@ func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int,
 		To:      accAddress.String(),
 		Amount:  amount,
 	}
-	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDeposit}, &txOption)
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDeposit}, txOption)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +49,7 @@ func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int,
 }
 
 // Withdraw withdraws BNB from a stream account.
-func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error) {
+func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error) {
 	accAddress, err := sdk.AccAddressFromHexUnsafe(fromAddress)
 	if err != nil {
 		return "", err
@@ -59,7 +59,7 @@ func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.I
 		From:    accAddress.String(),
 		Amount:  amount,
 	}
-	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgWithdraw}, &txOption)
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgWithdraw}, txOption)
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +67,7 @@ func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.I
 }
 
 // DisableRefund disables refund for a stream account.
-func (c *client) DisableRefund(ctx context.Context, paymentAddress string, txOption gnfdSdkTypes.TxOption) (string, error) {
+func (c *client) DisableRefund(ctx context.Context, paymentAddress string, txOption *gnfdSdkTypes.TxOption) (string, error) {
 	accAddress, err := sdk.AccAddressFromHexUnsafe(paymentAddress)
 	if err != nil {
 		return "", err
@@ -76,7 +76,7 @@ func (c *client) DisableRefund(ctx context.Context, paymentAddress string, txOpt
 		Owner: c.MustGetDefaultAccount().GetAddress().String(),
 		Addr:  accAddress.String(),
 	}
-	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDisableRefund}, &txOption)
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDisableRefund}, txOption)
 	if err != nil {
 		return "", err
 	}

--- a/client/api_payment.go
+++ b/client/api_payment.go
@@ -12,9 +12,9 @@ import (
 type Payment interface {
 	GetStreamRecord(ctx context.Context, streamAddress string) (*paymentTypes.StreamRecord, error)
 
-	Deposit(ctx context.Context, toAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error)
-	Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error)
-	DisableRefund(ctx context.Context, paymentAddress string, txOption *gnfdSdkTypes.TxOption) (string, error)
+	Deposit(ctx context.Context, toAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error)
+	Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error)
+	DisableRefund(ctx context.Context, paymentAddress string, txOption gnfdSdkTypes.TxOption) (string, error)
 }
 
 // GetStreamRecord retrieves stream record information for a given stream address.
@@ -31,7 +31,7 @@ func (c *client) GetStreamRecord(ctx context.Context, streamAddress string) (*pa
 }
 
 // Deposit deposits BNB to a stream account.
-func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error) {
+func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error) {
 	accAddress, err := sdk.AccAddressFromHexUnsafe(toAddress)
 	if err != nil {
 		return "", err
@@ -41,7 +41,7 @@ func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int,
 		To:      accAddress.String(),
 		Amount:  amount,
 	}
-	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDeposit}, txOption)
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDeposit}, &txOption)
 	if err != nil {
 		return "", err
 	}
@@ -49,7 +49,7 @@ func (c *client) Deposit(ctx context.Context, toAddress string, amount math.Int,
 }
 
 // Withdraw withdraws BNB from a stream account.
-func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption *gnfdSdkTypes.TxOption) (string, error) {
+func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.Int, txOption gnfdSdkTypes.TxOption) (string, error) {
 	accAddress, err := sdk.AccAddressFromHexUnsafe(fromAddress)
 	if err != nil {
 		return "", err
@@ -59,7 +59,7 @@ func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.I
 		From:    accAddress.String(),
 		Amount:  amount,
 	}
-	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgWithdraw}, txOption)
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgWithdraw}, &txOption)
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +67,7 @@ func (c *client) Withdraw(ctx context.Context, fromAddress string, amount math.I
 }
 
 // DisableRefund disables refund for a stream account.
-func (c *client) DisableRefund(ctx context.Context, paymentAddress string, txOption *gnfdSdkTypes.TxOption) (string, error) {
+func (c *client) DisableRefund(ctx context.Context, paymentAddress string, txOption gnfdSdkTypes.TxOption) (string, error) {
 	accAddress, err := sdk.AccAddressFromHexUnsafe(paymentAddress)
 	if err != nil {
 		return "", err
@@ -76,7 +76,7 @@ func (c *client) DisableRefund(ctx context.Context, paymentAddress string, txOpt
 		Owner: c.MustGetDefaultAccount().GetAddress().String(),
 		Addr:  accAddress.String(),
 	}
-	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDisableRefund}, txOption)
+	tx, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{msgDisableRefund}, &txOption)
 	if err != nil {
 		return "", err
 	}

--- a/e2e/e2e_basic_test.go
+++ b/e2e/e2e_basic_test.go
@@ -69,7 +69,7 @@ func (s *BasicTestSuite) Test_Account() {
 	s.Require().Equal(acc.GetAddress(), account1.GetAddress())
 	s.Require().Equal(acc.GetSequence(), uint64(0))
 
-	txHash, err := s.Client.CreatePaymentAccount(s.ClientContext, s.DefaultAccount.GetAddress().String(), &types2.TxOption{})
+	txHash, err := s.Client.CreatePaymentAccount(s.ClientContext, s.DefaultAccount.GetAddress().String(), types2.TxOption{})
 	s.Require().NoError(err)
 	s.T().Logf("Acc: %s", txHash)
 	waitForTx, err = s.Client.WaitForTx(s.ClientContext, txHash)
@@ -143,7 +143,7 @@ func (s *BasicTestSuite) Test_Payment() {
 
 	paymentAccountsBeforeCreate, err := cli.GetPaymentAccountsByOwner(ctx, account.GetAddress().String())
 	s.Require().NoError(err)
-	txHash, err := cli.CreatePaymentAccount(ctx, account.GetAddress().String(), &types2.TxOption{})
+	txHash, err := cli.CreatePaymentAccount(ctx, account.GetAddress().String(), types2.TxOption{})
 	s.Require().NoError(err)
 	t.Logf("Acc: %s", txHash)
 	waitForTx, err := cli.WaitForTx(ctx, txHash)
@@ -157,7 +157,7 @@ func (s *BasicTestSuite) Test_Payment() {
 	// deposit
 	paymentAddr := paymentAccountsByOwnerAfterCreate[len(paymentAccountsByOwnerAfterCreate)-1].Addr
 	depositAmount := math.NewIntFromUint64(100)
-	depositTxHash, err := cli.Deposit(ctx, paymentAddr, depositAmount, nil)
+	depositTxHash, err := cli.Deposit(ctx, paymentAddr, depositAmount, types2.TxOption{})
 	s.Require().NoError(err)
 	t.Logf("deposit tx: %s", depositTxHash)
 	waitForTx, err = cli.WaitForTx(ctx, depositTxHash)
@@ -171,7 +171,7 @@ func (s *BasicTestSuite) Test_Payment() {
 
 	// withdraw
 	withdrawAmount := math.NewIntFromUint64(50)
-	withdrawTxHash, err := cli.Withdraw(ctx, paymentAddr, withdrawAmount, nil)
+	withdrawTxHash, err := cli.Withdraw(ctx, paymentAddr, withdrawAmount, types2.TxOption{})
 	s.Require().NoError(err)
 	t.Logf("withdraw tx: %s", withdrawTxHash)
 	waitForTx, err = cli.WaitForTx(ctx, withdrawTxHash)
@@ -185,7 +185,7 @@ func (s *BasicTestSuite) Test_Payment() {
 	paymentAccountBeforeDisableRefund, err := cli.GetPaymentAccount(ctx, paymentAddr)
 	s.Require().NoError(err)
 	s.Require().True(paymentAccountBeforeDisableRefund.Refundable)
-	disableRefundTxHash, err := cli.DisableRefund(ctx, paymentAddr, nil)
+	disableRefundTxHash, err := cli.DisableRefund(ctx, paymentAddr, types2.TxOption{})
 	s.Require().NoError(err)
 	t.Logf("disable refund tx: %s", disableRefundTxHash)
 	waitForTx, err = cli.WaitForTx(ctx, disableRefundTxHash)

--- a/e2e/e2e_basic_test.go
+++ b/e2e/e2e_basic_test.go
@@ -2,6 +2,7 @@ package e2e
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 
 	"cosmossdk.io/math"
@@ -81,20 +82,11 @@ func (s *BasicTestSuite) Test_Account() {
 	s.Require().Equal(len(paymentAccountsByOwner), 1)
 }
 
-func TestBasicTestSuite(t *testing.T) {
-	suite.Run(t, new(BasicTestSuite))
-}
-
-func Test_Payment(t *testing.T) {
-	mnemonic := ParseValidatorMnemonic(0)
-	account, err := types.NewAccountFromMnemonic("test", mnemonic)
-	assert.NoError(t, err)
-	cli, err := client.New(ChainID, Endpoint, client.Option{
-		DefaultAccount: account,
-		GrpcDialOption: grpc.WithTransportCredentials(insecure.NewCredentials())},
-	)
-	assert.NoError(t, err)
-	ctx := context.Background()
+func (s *BasicTestSuite) Test_Payment() {
+	account := s.DefaultAccount
+	cli := s.Client
+	t := s.T()
+	ctx := s.ClientContext
 
 	txHash, err := cli.CreatePaymentAccount(ctx, account.GetAddress().String(), &types2.TxOption{})
 	assert.NoError(t, err)
@@ -145,4 +137,8 @@ func Test_Payment(t *testing.T) {
 	paymentAccountsByOwner, err = cli.GetPaymentAccountsByOwner(ctx, account.GetAddress().String())
 	assert.NoError(t, err)
 	assert.False(t, paymentAccountsByOwner[0].Refundable)
+}
+
+func TestBasicTestSuite(t *testing.T) {
+	suite.Run(t, new(BasicTestSuite))
 }

--- a/e2e/e2e_basic_test.go
+++ b/e2e/e2e_basic_test.go
@@ -127,16 +127,18 @@ func (s *BasicTestSuite) Test_Payment() {
 	assert.Equal(t, streamRecordAfterWithdraw.StaticBalance.String(), depositAmount.Sub(withdrawAmount).String())
 
 	// disable refund
-	assert.True(t, paymentAccountsByOwner[0].Refundable)
+	paymentAccountBeforeDisableRefund, err := cli.GetPaymentAccount(ctx, paymentAddr)
+	assert.NoError(t, err)
+	assert.True(t, paymentAccountBeforeDisableRefund.Refundable)
 	disableRefundTxHash, err := cli.DisableRefund(ctx, paymentAddr, nil)
 	assert.NoError(t, err)
 	t.Logf("disable refund tx: %s", disableRefundTxHash)
 	waitForTx, err = cli.WaitForTx(ctx, disableRefundTxHash)
 	assert.NoError(t, err)
 	t.Logf("Wair for tx: %s", waitForTx.String())
-	paymentAccountsByOwner, err = cli.GetPaymentAccountsByOwner(ctx, account.GetAddress().String())
+	paymentAccountAfterDisableRefund, err := cli.GetPaymentAccount(ctx, paymentAddr)
 	assert.NoError(t, err)
-	assert.False(t, paymentAccountsByOwner[0].Refundable)
+	assert.False(t, paymentAccountAfterDisableRefund.Refundable)
 }
 
 func TestBasicTestSuite(t *testing.T) {


### PR DESCRIPTION
### Description

Add payment client and sp functions.

### Rationale

Add payment client in new SDK, make it easier to invoke payment related queries and transactions.
Add more functions in Storage API.

### Example

```golang
// create payment account
paymentAccountsBeforeCreate, err := cli.GetPaymentAccountsByOwner(ctx, account.GetAddress().String())
s.Require().NoError(err)
txHash, err := cli.CreatePaymentAccount(ctx, account.GetAddress().String(), types2.TxOption{})
s.Require().NoError(err)
t.Logf("Acc: %s", txHash)
waitForTx, err := cli.WaitForTx(ctx, txHash)
s.Require().NoError(err)
t.Logf("Wair for tx: %s", waitForTx.String())

paymentAccountsByOwnerAfterCreate, err := cli.GetPaymentAccountsByOwner(ctx, account.GetAddress().String())
s.Require().NoError(err)
s.Require().Equal(len(paymentAccountsByOwnerAfterCreate)-len(paymentAccountsBeforeCreate), 1)

// deposit
paymentAddr := paymentAccountsByOwnerAfterCreate[len(paymentAccountsByOwnerAfterCreate)-1].Addr
depositAmount := math.NewIntFromUint64(100)
depositTxHash, err := cli.Deposit(ctx, paymentAddr, depositAmount, types2.TxOption{})
s.Require().NoError(err)
t.Logf("deposit tx: %s", depositTxHash)
waitForTx, err = cli.WaitForTx(ctx, depositTxHash)
s.Require().NoError(err)
t.Logf("Wair for tx: %s", waitForTx.String())

// get stream record
streamRecord, err := cli.GetStreamRecord(ctx, paymentAddr)
s.Require().NoError(err)
s.Require().Equal(streamRecord.StaticBalance.String(), depositAmount.String())

// withdraw
withdrawAmount := math.NewIntFromUint64(50)
withdrawTxHash, err := cli.Withdraw(ctx, paymentAddr, withdrawAmount, types2.TxOption{})
s.Require().NoError(err)
t.Logf("withdraw tx: %s", withdrawTxHash)
waitForTx, err = cli.WaitForTx(ctx, withdrawTxHash)
s.Require().NoError(err)
t.Logf("Wair for tx: %s", waitForTx.String())
streamRecordAfterWithdraw, err := cli.GetStreamRecord(ctx, paymentAddr)
s.Require().NoError(err)
s.Require().Equal(streamRecordAfterWithdraw.StaticBalance.String(), depositAmount.Sub(withdrawAmount).String())

// disable refund
paymentAccountBeforeDisableRefund, err := cli.GetPaymentAccount(ctx, paymentAddr)
s.Require().NoError(err)
s.Require().True(paymentAccountBeforeDisableRefund.Refundable)
disableRefundTxHash, err := cli.DisableRefund(ctx, paymentAddr, types2.TxOption{})
s.Require().NoError(err)
t.Logf("disable refund tx: %s", disableRefundTxHash)
waitForTx, err = cli.WaitForTx(ctx, disableRefundTxHash)
s.Require().NoError(err)
t.Logf("Wair for tx: %s", waitForTx.String())
paymentAccountAfterDisableRefund, err := cli.GetPaymentAccount(ctx, paymentAddr)
s.Require().NoError(err)
s.Require().False(paymentAccountAfterDisableRefund.Refundable)
```

### Changes

Notable changes:
* add payment client