### PR TITLE
fix: fix  potential url error of http request

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -412,13 +412,10 @@ func (c *client) generateURL(bucketName string, objectName string, relativePath 
 		urlStr = scheme + "://" + host + "/"
 		if bucketName != "" {
 			if isVirtualHost {
+				// set virtual host url
 				urlStr = scheme + "://" + bucketName + "." + host + "/"
-
-				if objectName != "" {
-					urlStr += utils.EncodePath(objectName)
-				}
 			} else {
-				// set path style
+				// set path style url
 				urlStr = urlStr + bucketName + "/"
 			}
 


### PR DESCRIPTION
### Description
fix the URL error, the virtual host URL may have more than one object name.

### Rationale

URL may contain more than one object name, need  remove duplicate logic

### Example

NA

### Changes

Notable changes:
* fix the URL error, remove duplicate logic