### PR TITLE
refactor: add err log and trace for SP msg

### DIFF
--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -80,10 +80,10 @@ func (c *client) GetCreateBucketApproval(ctx context.Context, createBucketMsg *s
 		isAdminApi: true,
 	}
 
-	primarySP := createBucketMsg.GetPrimarySpAddress()
-	endpoint, err := c.getSPUrlByAddr(primarySP)
+	primarySPAddr := createBucketMsg.GetPrimarySpAddress()
+	endpoint, err := c.getSPUrlByAddr(primarySPAddr)
 	if err != nil {
-		log.Error().Msg(fmt.Sprintf("route endpoint by addr: %s failed, err: %s", primarySP, err.Error()))
+		log.Error().Msg(fmt.Sprintf("route endpoint by addr: %s failed, err: %s", primarySPAddr, err.Error()))
 		return nil, err
 	}
 

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -14,14 +14,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/bnb-chain/greenfield-go-sdk/pkg/utils"
-	"github.com/bnb-chain/greenfield-go-sdk/types"
+	gnfdsdk "github.com/bnb-chain/greenfield/sdk/types"
 	gnfdTypes "github.com/bnb-chain/greenfield/types"
 	"github.com/bnb-chain/greenfield/types/s3util"
 	permTypes "github.com/bnb-chain/greenfield/x/permission/types"
 	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/rs/zerolog/log"
+
+	"github.com/bnb-chain/greenfield-go-sdk/pkg/utils"
+	"github.com/bnb-chain/greenfield-go-sdk/types"
 )
 
 type Bucket interface {
@@ -129,6 +132,12 @@ func (c *client) CreateBucket(ctx context.Context, bucketName string, primaryAdd
 		return "", err
 	}
 
+	// set the default txn broadcast mode as block mode
+	if opts.TxOpts == nil {
+		broadcastMode := tx.BroadcastMode_BROADCAST_MODE_BLOCK
+		opts.TxOpts = &gnfdsdk.TxOption{Mode: &broadcastMode}
+	}
+
 	resp, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{signedMsg}, opts.TxOpts)
 	if err != nil {
 		return "", err
@@ -213,6 +222,13 @@ func (c *client) UpdateBucketInfo(ctx context.Context, bucketName string, opts t
 
 	updateBucketMsg := storageTypes.NewMsgUpdateBucketInfo(c.MustGetDefaultAccount().GetAddress(), bucketName,
 		&chargedReadQuota, paymentAddr, visibility)
+
+	// set the default txn broadcast mode as block mode
+	if opts.TxOpts == nil {
+		broadcastMode := tx.BroadcastMode_BROADCAST_MODE_BLOCK
+		opts.TxOpts = &gnfdsdk.TxOption{Mode: &broadcastMode}
+	}
+	
 	return c.sendTxn(ctx, updateBucketMsg, opts.TxOpts)
 }
 

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -123,8 +123,16 @@ func (c *client) CreateBucket(ctx context.Context, bucketName string, primaryAdd
 		visibility = opts.Visibility
 	}
 
+	var paymentAddr sdk.AccAddress
+	if opts.PaymentAddress != "" {
+		paymentAddr, err = sdk.AccAddressFromHexUnsafe(opts.PaymentAddress)
+		if err != nil {
+			return "", err
+		}
+	}
+
 	createBucketMsg := storageTypes.NewMsgCreateBucket(c.MustGetDefaultAccount().GetAddress(), bucketName,
-		visibility, address, opts.PaymentAddress, 0, nil, opts.ChargedQuota)
+		visibility, address, paymentAddr, 0, nil, opts.ChargedQuota)
 
 	err = createBucketMsg.ValidateBasic()
 	if err != nil {
@@ -194,7 +202,7 @@ func (c *client) UpdateBucketInfo(ctx context.Context, bucketName string, opts t
 		return "", err
 	}
 
-	if opts.Visibility == bucketInfo.Visibility && opts.PaymentAddress == nil && opts.ChargedQuota == nil {
+	if opts.Visibility == bucketInfo.Visibility && opts.PaymentAddress == "" && opts.ChargedQuota == nil {
 		return "", errors.New("no meta need to update")
 	}
 
@@ -208,8 +216,11 @@ func (c *client) UpdateBucketInfo(ctx context.Context, bucketName string, opts t
 		visibility = bucketInfo.Visibility
 	}
 
-	if len(opts.PaymentAddress) > 0 {
-		paymentAddr = opts.PaymentAddress
+	if opts.PaymentAddress != "" {
+		paymentAddr, err = sdk.AccAddressFromHexUnsafe(opts.PaymentAddress)
+		if err != nil {
+			return "", err
+		}
 	} else {
 		paymentAddr, err = sdk.AccAddressFromHexUnsafe(bucketInfo.PaymentAddress)
 		if err != nil {

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -348,6 +348,7 @@ func (c *client) ListBuckets(ctx context.Context) (types.ListBucketsResult, erro
 
 	endpoint, err := c.getInServiceSP()
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("get in-service SP fail %s", err.Error()))
 		return types.ListBucketsResult{}, err
 	}
 

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"errors"
+	"fmt"
 	"io"
 	"math"
 	"net/http"
@@ -79,8 +80,10 @@ func (c *client) GetCreateBucketApproval(ctx context.Context, createBucketMsg *s
 		isAdminApi: true,
 	}
 
-	endpoint, err := c.getSPUrlByAddr(createBucketMsg.GetPrimarySpAddress())
+	primarySP := createBucketMsg.GetPrimarySpAddress()
+	endpoint, err := c.getSPUrlByAddr(primarySP)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by addr: %s failed, err: %s", primarySP, err.Error()))
 		return nil, err
 	}
 
@@ -228,7 +231,7 @@ func (c *client) UpdateBucketInfo(ctx context.Context, bucketName string, opts t
 		broadcastMode := tx.BroadcastMode_BROADCAST_MODE_BLOCK
 		opts.TxOpts = &gnfdsdk.TxOption{Mode: &broadcastMode}
 	}
-	
+
 	return c.sendTxn(ctx, updateBucketMsg, opts.TxOpts)
 }
 
@@ -424,6 +427,7 @@ func (c *client) ListBucketReadRecord(ctx context.Context, bucketName string, op
 
 	endpoint, err := c.getSPUrlByBucket(bucketName)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %s", bucketName, err.Error()))
 		return types.QuotaRecordInfo{}, err
 	}
 
@@ -474,6 +478,7 @@ func (c *client) GetBucketReadQuota(ctx context.Context, bucketName string) (typ
 
 	endpoint, err := c.getSPUrlByBucket(bucketName)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %s", bucketName, err.Error()))
 		return types.QuotaInfo{}, err
 	}
 

--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -2,13 +2,16 @@ package client
 
 import (
 	"context"
-	"cosmossdk.io/math"
 	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"cosmossdk.io/math"
 	gnfdsdktypes "github.com/bnb-chain/greenfield/sdk/types"
 	challengetypes "github.com/bnb-chain/greenfield/x/challenge/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"net/http"
-	"strings"
+	"github.com/rs/zerolog/log"
 
 	"github.com/bnb-chain/greenfield-go-sdk/pkg/utils"
 	types "github.com/bnb-chain/greenfield-go-sdk/types"
@@ -54,8 +57,10 @@ func (c *client) GetChallengeInfo(ctx context.Context, info types.ChallengeInfo)
 		return types.ChallengeResult{}, err
 	}
 
-	endpoint, err := c.getSPUrlByBucket(objectInfo.BucketName)
+	bucketName := objectInfo.BucketName
+	endpoint, err := c.getSPUrlByBucket(bucketName)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %s", bucketName, err.Error()))
 		return types.ChallengeResult{}, err
 	}
 

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -563,7 +563,6 @@ func (c *client) dumpSPMsg(req *http.Request, resp *http.Response) {
 		return
 	}
 
-	return
 }
 
 // GetPieceHashRoots returns primary pieces, secondary piece Hash roots list and the object size

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -150,7 +150,7 @@ func (c *client) getSPUrlByBucket(bucketName string) (*url.URL, error) {
 		return newSpInfo[primarySP], nil
 	}
 
-	return nil, errors.New(fmt.Sprintf("the SP endpoint %s not exists on chain", primarySP))
+	return nil, fmt.Errorf("the SP endpoint %s not exists on chain", primarySP)
 }
 
 // getSPUrlByAddr route url of the sp from sp address
@@ -169,7 +169,7 @@ func (c *client) getSPUrlByAddr(address string) (*url.URL, error) {
 		return newSpInfo[address], nil
 	}
 
-	return nil, errors.New(fmt.Sprintf("the SP endpoint %s not exists on chain", address))
+	return nil, fmt.Errorf("the SP endpoint %s not exists on chain", address)
 }
 
 // getInServiceSP return the first SP endpoint which is in service in SP list
@@ -387,6 +387,7 @@ func (c *client) doAPI(ctx context.Context, req *http.Request, meta requestMeta,
 	// construct err responses and messages
 	err = types.ConstructErrResponse(resp, meta.bucketName, meta.objectName)
 	if err != nil {
+		// dump error msg
 		if c.isTraceEnabled {
 			err = c.dumpSPMsg(req, resp)
 			if err != nil {

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -234,6 +234,7 @@ func (c *client) newRequest(ctx context.Context, method string, meta requestMeta
 	desURL, err := c.generateURL(meta.bucketName, meta.objectName, meta.urlRelPath,
 		meta.urlValues, isAdminAPi, endpoint, isVirtualHost)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("generate request url on SP: %s fail, err: %s", endpoint.String(), err))
 		return nil, err
 	}
 
@@ -387,7 +388,7 @@ func (c *client) doAPI(ctx context.Context, req *http.Request, meta requestMeta,
 	err = types.ConstructErrResponse(resp, meta.bucketName, meta.objectName)
 	if err != nil {
 		if c.isTraceEnabled {
-			err = c.dumpSPAPI(req, resp)
+			err = c.dumpSPMsg(req, resp)
 			if err != nil {
 				return nil, err
 			}
@@ -504,8 +505,13 @@ func (c *client) isVirtualHostStyleUrl(url url.URL, bucketName string) bool {
 	return true
 }
 
-func (c *client) dumpSPAPI(req *http.Request, resp *http.Response) error {
+func (c *client) dumpSPMsg(req *http.Request, resp *http.Response) error {
 	_, err := fmt.Fprintln(c.traceOutput, "---------START-TRACE---------")
+	if err != nil {
+		return err
+	}
+	// write header info to trace output.
+	_, err = fmt.Fprint(c.traceOutput, string(req.URL.String()))
 	if err != nil {
 		return err
 	}

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -524,7 +524,7 @@ func (c *client) dumpSPMsg(req *http.Request, resp *http.Response) {
 		return
 	}
 	// write url info to trace output.
-	_, err = fmt.Fprint(c.traceOutput, string(req.URL.String()))
+	_, err = fmt.Fprintln(c.traceOutput, req.URL.String())
 	if err != nil {
 		return
 	}

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -63,6 +63,8 @@ type client struct {
 	host string
 	// The user agent info
 	userAgent string
+	// define if trace the error request to SP
+	isTraceEnabled bool
 }
 
 // Option is a configuration struct used to provide optional parameters to the client constructor.
@@ -133,9 +135,9 @@ func (c *client) getSPUrlByBucket(bucketName string) (*url.URL, error) {
 	if _, ok := newSpInfo[primarySP]; ok {
 		c.spEndpoints = newSpInfo
 		return newSpInfo[primarySP], nil
-	} else {
-		return nil, errors.New("fail to locate endpoint from bucket")
 	}
+
+	return nil, errors.New(fmt.Sprintf("the SP endpoint %s not exists on chain", primarySP))
 }
 
 // getSPUrlByAddr route url of the sp from sp address
@@ -152,9 +154,9 @@ func (c *client) getSPUrlByAddr(address string) (*url.URL, error) {
 	if _, ok := newSpInfo[address]; ok {
 		c.spEndpoints = newSpInfo
 		return newSpInfo[address], nil
-	} else {
-		return nil, errors.New("fail to locate endpoint from address")
 	}
+
+	return nil, errors.New(fmt.Sprintf("the SP endpoint %s not exists on chain", address))
 }
 
 // getInServiceSP return the first SP endpoint which is in service in SP list

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -512,7 +512,7 @@ func (c *client) isVirtualHostStyleUrl(url url.URL, bucketName string) bool {
 	return true
 }
 
-func (c *client) dumpSPMsg(req *http.Request, resp *http.Response) error {
+func (c *client) dumpSPMsg(req *http.Request, resp *http.Response) {
 	var err error
 	defer func() {
 		if err != nil {
@@ -521,49 +521,49 @@ func (c *client) dumpSPMsg(req *http.Request, resp *http.Response) error {
 	}()
 	_, err = fmt.Fprintln(c.traceOutput, "---------TRACE REQUEST---------")
 	if err != nil {
-		return err
+		return
 	}
 	// write url info to trace output.
 	_, err = fmt.Fprint(c.traceOutput, string(req.URL.String()))
 	if err != nil {
-		return err
+		return
 	}
 
 	// dump headers
 	reqTrace, err := httputil.DumpRequestOut(req, false)
 	if err != nil {
-		return err
+		return
 	}
 
 	// write header info to trace output.
 	_, err = fmt.Fprint(c.traceOutput, string(reqTrace))
 	if err != nil {
-		return err
+		return
 	}
 
 	_, err = fmt.Fprintln(c.traceOutput, "---------TRACE RESPONSE---------")
 	if err != nil {
-		return err
+		return
 	}
 
 	// dump response
 	respInfo, err := httputil.DumpResponse(resp, true)
 	if err != nil {
-		return err
+		return
 	}
 
 	// Write response info to trace output.
 	_, err = fmt.Fprint(c.traceOutput, strings.TrimSuffix(string(respInfo), "\r\n"))
 	if err != nil {
-		return err
+		return
 	}
 
 	_, err = fmt.Fprintln(c.traceOutput, "---------END-STRACE---------")
 	if err != nil {
-		return err
+		return
 	}
 
-	return nil
+	return
 }
 
 // GetPieceHashRoots returns primary pieces, secondary piece Hash roots list and the object size

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -222,6 +222,7 @@ func (c *client) PutObject(ctx context.Context, bucketName, objectName string, o
 
 	endpoint, err := c.getSPUrlByBucket(bucketName)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %s", bucketName, err.Error()))
 		return err
 	}
 
@@ -279,6 +280,7 @@ func (c *client) GetObject(ctx context.Context, bucketName, objectName string,
 
 	endpoint, err := c.getSPUrlByBucket(bucketName)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed,  err: %s", bucketName, err.Error()))
 		return nil, types.ObjectStat{}, err
 	}
 
@@ -476,6 +478,7 @@ func (c *client) ListObjects(ctx context.Context, bucketName string, opts types.
 
 	endpoint, err := c.getSPUrlByBucket(bucketName)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %s", bucketName, err.Error()))
 		return types.ListObjectsResult{}, err
 	}
 
@@ -540,8 +543,10 @@ func (c *client) GetCreateObjectApproval(ctx context.Context, createObjectMsg *s
 		isAdminApi: true,
 	}
 
-	endpoint, err := c.getSPUrlByBucket(createObjectMsg.BucketName)
+	bucketName := createObjectMsg.BucketName
+	endpoint, err := c.getSPUrlByBucket(bucketName)
 	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %s", bucketName, err.Error()))
 		return nil, err
 	}
 

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -16,14 +16,17 @@ import (
 	"strings"
 
 	hashlib "github.com/bnb-chain/greenfield-common/go/hash"
-	"github.com/bnb-chain/greenfield-go-sdk/pkg/utils"
-	"github.com/bnb-chain/greenfield-go-sdk/types"
+	gnfdsdk "github.com/bnb-chain/greenfield/sdk/types"
 	gnfdTypes "github.com/bnb-chain/greenfield/types"
 	"github.com/bnb-chain/greenfield/types/s3util"
 	permTypes "github.com/bnb-chain/greenfield/x/permission/types"
 	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/rs/zerolog/log"
+
+	"github.com/bnb-chain/greenfield-go-sdk/pkg/utils"
+	"github.com/bnb-chain/greenfield-go-sdk/types"
 )
 
 type Object interface {
@@ -136,6 +139,12 @@ func (c *client) CreateObject(ctx context.Context, bucketName, objectName string
 	signedCreateObjectMsg, err := c.GetCreateObjectApproval(ctx, createObjectMsg)
 	if err != nil {
 		return "", err
+	}
+
+	// set the default txn broadcast mode as block mode
+	if opts.TxOpts == nil {
+		broadcastMode := tx.BroadcastMode_BROADCAST_MODE_BLOCK
+		opts.TxOpts = &gnfdsdk.TxOption{Mode: &broadcastMode}
 	}
 
 	resp, err := c.chainClient.BroadcastTx(ctx, []sdk.Msg{signedCreateObjectMsg}, opts.TxOpts)

--- a/client/api_sp.go
+++ b/client/api_sp.go
@@ -103,6 +103,7 @@ func (c *client) getSPUrlList() (map[string]*url.URL, error) {
 	if err != nil {
 		return nil, err
 	}
+
 	spList := gnfdRep.GetSps()
 	if len(spList) == 0 {
 		return nil, errors.New("no SP found on chain")

--- a/types/const.go
+++ b/types/const.go
@@ -6,7 +6,7 @@ import (
 
 const (
 	libName   = "greenfield-go-sdk"
-	Version   = "v0.0.7"
+	Version   = "v0.1.0"
 	UserAgent = "Greenfield (" + runtime.GOOS + "; " + runtime.GOARCH + ") " + libName + "/" + Version
 
 	HTTPHeaderAuthorization = "Authorization"

--- a/types/option.go
+++ b/types/option.go
@@ -11,10 +11,11 @@ import (
 )
 
 // CreateBucketOptions indicates the meta to construct createBucket msg of storage module
+// PaymentAddress  indicates the HEX-encoded string of the payment address
 type CreateBucketOptions struct {
 	Visibility     storageTypes.VisibilityType
 	TxOpts         *gnfdsdktypes.TxOption
-	PaymentAddress sdk.AccAddress
+	PaymentAddress string
 	ChargedQuota   uint64
 }
 
@@ -50,10 +51,12 @@ type UpdatePaymentOption struct {
 	TxOpts *gnfdsdktypes.TxOption
 }
 
+// UpdateBucketOption indicates the meta to construct updateBucket msg of storage module
+// PaymentAddress  indicates the HEX-encoded string of the payment address
 type UpdateBucketOption struct {
 	Visibility     storageTypes.VisibilityType
 	TxOpts         *gnfdsdktypes.TxOption
-	PaymentAddress sdk.AccAddress
+	PaymentAddress string
 	ChargedQuota   *uint64
 }
 


### PR DESCRIPTION
### Description
1. set the default txn broadcast mode as block of create object, create bucket, update bucket
2. add trace option to dump http info of SP message
3. add error log 

### Rationale

help to locate the error 

dump message
<img width="1226" alt="image" src="https://user-images.githubusercontent.com/19421226/234263366-004cf10e-a41c-457c-9c3f-2ff7b5dcbdb2.png">


### Example

cli.EnableTrace(nil, true)

### Changes

Notable changes:
* add trace option to dump http info
