### PR TITLE
fix: remove challenge address verify when it is empty

### DIFF
--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -123,9 +123,11 @@ func (c *client) AttestChallenge(ctx context.Context, submitterAddress, challeng
 	if err != nil {
 		return nil, err
 	}
-	_, err = sdk.AccAddressFromHexUnsafe(challengerAddress)
-	if err != nil {
-		return nil, err
+	if challengerAddress != "" {
+		_, err = sdk.AccAddressFromHexUnsafe(challengerAddress)
+		if err != nil {
+			return nil, err
+		}
 	}
 	_, err = sdk.AccAddressFromHexUnsafe(spOperatorAddress)
 	if err != nil {


### PR DESCRIPTION
### Description

This pr removes challenge address verify when it is empty.

### Rationale

Challenge address could be empty.

### Example

NA

### Changes

Notable changes:
* challenge