### PR TITLE
feat: update list objects 

### DIFF
--- a/client/api_object.go
+++ b/client/api_object.go
@@ -568,7 +568,7 @@ func (c *client) ListObjects(ctx context.Context, bucketName, maxKeys, startAfte
 	}
 
 	listObjectsResult.Objects = objectMetaList
-	listObjectsResult.KeyCount = uint64(len(objectMetaList))
+	listObjectsResult.KeyCount = strconv.Itoa(len(objectMetaList))
 	return listObjectsResult, nil
 }
 

--- a/types/list.go
+++ b/types/list.go
@@ -43,7 +43,16 @@ type UploadProgress struct {
 
 type ListObjectsResult struct {
 	// objects defines the list of object
-	Objects []*ObjectMeta `json:"objects"`
+	Objects               []*ObjectMeta `json:"objects"`
+	KeyCount              string        `json:"key_count"`
+	MaxKeys               string        `json:"max_keys"`
+	IsTruncated           bool          `json:"is_truncated"`
+	NextContinuationToken string        `json:"next_continuation_token"`
+	Name                  string        `json:"name"`
+	Prefix                string        `json:"prefix"`
+	Delimiter             string        `json:"delimiter"`
+	CommonPrefixes        []string      `json:"common_prefixes"`
+	ContinuationToken     string        `json:"continuation_token"`
 }
 
 type ListBucketsResult struct {


### PR DESCRIPTION
### Description

list objects pagination & folder path

### Rationale

N/A

### Example

```
curl --location --request GET 'http://barry.localhost:9033?continuation-token=&start-after&delimiter=/&prefix=my_folder1/&max-keys=9' \
--header 'Authorization: authTypeV2 ECDSA-secp256k1, Signature=1234567812345678123456781234567812345678123456781234567812345678'
```

### Changes

Notable changes:
* pagination feature for Listobjectbybucketname
* support folder path with prefix and delimiter query