### PR TITLE
feat: support update-object

### DIFF
--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -36,7 +36,7 @@ type Bucket interface {
 	DeleteBucket(ctx context.Context, bucketName string, opt types.DeleteBucketOption) (string, error)
 
 	UpdateBucketVisibility(ctx context.Context, bucketName string, visibility storageTypes.VisibilityType, opt types.UpdateVisibilityOption) (string, error)
-	UpdateBucketInfo(ctx context.Context, bucketName string, opts types.UpdateBucketOption) (string, error)
+	UpdateBucketInfo(ctx context.Context, bucketName string, opts types.UpdateBucketOptions) (string, error)
 	UpdateBucketPaymentAddr(ctx context.Context, bucketName string, paymentAddr sdk.AccAddress, opt types.UpdatePaymentOption) (string, error)
 
 	HeadBucket(ctx context.Context, bucketName string) (*storageTypes.BucketInfo, error)
@@ -206,7 +206,7 @@ func (c *client) UpdateBucketPaymentAddr(ctx context.Context, bucketName string,
 }
 
 // UpdateBucketInfo update the bucket meta on chain, including read quota, payment address or visibility
-func (c *client) UpdateBucketInfo(ctx context.Context, bucketName string, opts types.UpdateBucketOption) (string, error) {
+func (c *client) UpdateBucketInfo(ctx context.Context, bucketName string, opts types.UpdateBucketOptions) (string, error) {
 	bucketInfo, err := c.HeadBucket(ctx, bucketName)
 	if err != nil {
 		return "", err

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -46,7 +46,8 @@ type Object interface {
 	// HeadObjectByID query the objectInfo on chain by object id, return the object info if exists
 	// return err info if object not exist
 	HeadObjectByID(ctx context.Context, objID string) (*storageTypes.ObjectInfo, error)
-
+	// UpdateObjectVisibility update the visibility of the object
+	UpdateObjectVisibility(ctx context.Context, bucketName, objectName string, visibility storageTypes.VisibilityType, opt types.UpdateObjectOption) (string, error)
 	// PutObjectPolicy apply object policy to the principal, return the txn hash
 	PutObjectPolicy(ctx context.Context, bucketName, objectName string, principalStr types.Principal,
 		statements []*permTypes.Statement, opt types.PutPolicyOption) (string, error)
@@ -656,4 +657,26 @@ func (c *client) getObjectStatusFromSP(ctx context.Context, bucketName, objectNa
 	}
 
 	return objectStatus, nil
+}
+
+func (c *client) UpdateObjectVisibility(ctx context.Context, bucketName, objectName string,
+	visibility storageTypes.VisibilityType, opt types.UpdateObjectOption) (string, error) {
+	objectInfo, err := c.HeadObject(ctx, bucketName, objectName)
+	if err != nil {
+		return "", fmt.Errorf("object:%s not exists: %s\n", objectName, err.Error())
+	}
+
+	if objectInfo.GetVisibility() == visibility {
+		return "", fmt.Errorf("the visibility of object:%s is already %s \n", objectName, visibility.String())
+	}
+
+	updateObjectMsg := storageTypes.NewMsgUpdateObjectInfo(c.MustGetDefaultAccount().GetAddress(), bucketName, objectName, visibility)
+
+	// set the default txn broadcast mode as sync mode
+	if opt.TxOpts == nil {
+		broadcastMode := tx.BroadcastMode_BROADCAST_MODE_SYNC
+		opt.TxOpts = &gnfdsdk.TxOption{Mode: &broadcastMode}
+	}
+
+	return c.sendTxn(ctx, updateObjectMsg, opt.TxOpts)
 }

--- a/types/option.go
+++ b/types/option.go
@@ -54,13 +54,17 @@ type UpdatePaymentOption struct {
 	TxOpts *gnfdsdktypes.TxOption
 }
 
-// UpdateBucketOption indicates the meta to construct updateBucket msg of storage module
+// UpdateBucketOptions indicates the meta to construct updateBucket msg of storage module
 // PaymentAddress  indicates the HEX-encoded string of the payment address
-type UpdateBucketOption struct {
+type UpdateBucketOptions struct {
 	Visibility     storageTypes.VisibilityType
 	TxOpts         *gnfdsdktypes.TxOption
 	PaymentAddress string
 	ChargedQuota   *uint64
+}
+
+type UpdateObjectOption struct {
+	TxOpts *gnfdsdktypes.TxOption
 }
 
 type CancelCreateOption struct {


### PR DESCRIPTION
### Description

support updating the visibility of the object,  added the interface of UpdateObjectVisibility in api_object.go

### Rationale

update object visibility is needed to supported

### Example

`client.UpdateObjectVisibility(ctx, bucketName, objectName, storageTypes.VISIBILITY_TYPE_PRIVATE, opt)
`
### Changes

Notable changes:
* support updating the visibility of the object