### PR TITLE
fix: support challenge to secondary sp 

### DIFF
--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 
 	"cosmossdk.io/math"
@@ -18,7 +19,7 @@ import (
 )
 
 type Challenge interface {
-	GetChallengeInfo(ctx context.Context, info types.ChallengeInfo) (types.ChallengeResult, error)
+	GetChallengeInfo(ctx context.Context, info types.ChallengeInfo, opts types.GetChallengeInfoOptions) (types.ChallengeResult, error)
 	SubmitChallenge(ctx context.Context, challengerAddress, spOperatorAddress, bucketName, objectName string, randomIndex bool, segmentIndex uint32, txOption gnfdsdktypes.TxOption) (*sdk.TxResponse, error)
 	AttestChallenge(ctx context.Context, submitterAddress, challengerAddress, spOperatorAddress string, challengeId uint64, objectId math.Uint, voteResult challengetypes.VoteResult, voteValidatorSet []uint64, VoteAggSignature []byte, txOption gnfdsdktypes.TxOption) (*sdk.TxResponse, error)
 	LatestAttestedChallenges(ctx context.Context, req *challengetypes.QueryLatestAttestedChallengesRequest) ([]uint64, error)
@@ -28,7 +29,7 @@ type Challenge interface {
 
 // GetChallengeInfo  sends request to challenge and get challenge result info
 // The challenge info includes the piece data, piece hash roots and integrity hash corresponding to the accessed SP
-func (c *client) GetChallengeInfo(ctx context.Context, info types.ChallengeInfo) (types.ChallengeResult, error) {
+func (c *client) GetChallengeInfo(ctx context.Context, info types.ChallengeInfo, opts types.GetChallengeInfoOptions) (types.ChallengeResult, error) {
 	if info.ObjectId == "" {
 		return types.ChallengeResult{}, errors.New("fail to get objectId")
 	}
@@ -37,8 +38,8 @@ func (c *client) GetChallengeInfo(ctx context.Context, info types.ChallengeInfo)
 		return types.ChallengeResult{}, errors.New("index error, should be 0 to parityShards plus dataShards")
 	}
 
-	if info.RedundancyIndex < -1 {
-		return types.ChallengeResult{}, errors.New("redundancy index error ")
+	if info.RedundancyIndex < -1 || info.RedundancyIndex > 5 {
+		return types.ChallengeResult{}, errors.New("redundancy index invalid, the index should be -1 to 5")
 	}
 
 	reqMeta := requestMeta{
@@ -53,16 +54,52 @@ func (c *client) GetChallengeInfo(ctx context.Context, info types.ChallengeInfo)
 		disableCloseBody: true,
 	}
 
-	objectInfo, err := c.HeadObjectByID(ctx, info.ObjectId)
-	if err != nil {
-		return types.ChallengeResult{}, err
-	}
+	var endpoint *url.URL
+	var err error
+	if opts.Endpoint != "" {
+		var useHttps bool
+		if strings.Contains(opts.Endpoint, "https") {
+			useHttps = true
+		} else {
+			useHttps = c.secure
+		}
 
-	bucketName := objectInfo.BucketName
-	endpoint, err := c.getSPUrlByBucket(bucketName)
-	if err != nil {
-		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %s", bucketName, err.Error()))
-		return types.ChallengeResult{}, err
+		endpoint, err = utils.GetEndpointURL(opts.Endpoint, useHttps)
+		if err != nil {
+			log.Error().Msg(fmt.Sprintf("fetch endpoint from opts %s fail:%v", opts.Endpoint, err))
+			return types.ChallengeResult{}, err
+		}
+	} else if opts.SPAddress != "" {
+		// get endpoint from sp address
+		endpoint, err = c.getSPUrlByAddr(opts.SPAddress)
+		if err != nil {
+			log.Error().Msg(fmt.Sprintf("route endpoint by sp address: %s failed, err: %v", opts.SPAddress, err))
+			return types.ChallengeResult{}, err
+		}
+	} else {
+		// get sp address info based on the redundancy index
+		objectInfo, err := c.HeadObjectByID(ctx, info.ObjectId)
+		if err != nil {
+			return types.ChallengeResult{}, err
+		}
+
+		index := info.RedundancyIndex
+		if info.RedundancyIndex == -1 {
+			// get endpoint of primary sp
+			endpoint, err = c.getSPUrlByBucket(objectInfo.BucketName)
+			if err != nil {
+				log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed, err: %v", objectInfo.BucketName, err))
+				return types.ChallengeResult{}, err
+			}
+		} else {
+			// get endpoint of the secondary sp
+			secondarySP := objectInfo.SecondarySpAddresses[index]
+			endpoint, err = c.getSPUrlByAddr(secondarySP)
+			if err != nil {
+				log.Error().Msg(fmt.Sprintf("route endpoint by sp address: %s failed, err: %v", secondarySP, err))
+				return types.ChallengeResult{}, err
+			}
+		}
 	}
 
 	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, endpoint)

--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -54,9 +54,9 @@ func (c *client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 		urlRelPath:    types.ChallengeUrl,
 		contentSHA256: types.EmptyStringSHA256,
 		challengeInfo: types.ChallengeInfo{
-			objectID,
-			pieceIndex,
-			redundancyIndex,
+			ObjectId:        objectID,
+			PieceIndex:      pieceIndex,
+			RedundancyIndex: redundancyIndex,
 		},
 	}
 

--- a/examples/group.go
+++ b/examples/group.go
@@ -51,11 +51,15 @@ func main() {
 		log.Fatalln("txn fail")
 	}
 
+	log.Printf("add group member: %s to group: %s successfully \n", groupMember, groupName)
+
 	// head group member
 	memIsExist := cli.HeadGroupMember(ctx, groupName, creator.GetAddress().String(), groupMember)
 	if !memIsExist {
 		log.Fatalf("head group member %s fail \n", groupMember)
 	}
+
+	log.Printf(" head member %s exist \n", groupMember)
 
 	// delete group
 	delTx, err := cli.DeleteGroup(ctx, groupName, types.DeleteGroupOption{})
@@ -64,4 +68,6 @@ func main() {
 	if err != nil {
 		log.Fatalln("txn fail")
 	}
+
+	log.Printf("group: %s has been deleted\n", groupName)
 }

--- a/examples/permission.go
+++ b/examples/permission.go
@@ -13,7 +13,7 @@ import (
 // it is the example of basic permission SDKs usage
 // the storage example need to run before permission examples to make sure the resources has been created
 func main() {
-	// you need to set the principal address in config.go to run this exampls
+	// you need to set the principal address in config.go to run this examples
 	if len(principal) < 42 {
 		log.Println("please set principal if you need run permission test")
 		return
@@ -42,6 +42,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("txn fail")
 	}
+	log.Printf("put bucket %s policy sucessfully, principal is: %s.\n", bucketName, principal)
 
 	// get bucket policy
 	policyInfo, err := cli.GetBucketPolicy(ctx, bucketName, principal)
@@ -69,6 +70,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("txn fail")
 	}
+	log.Printf("put object: %s policy sucessfully, principal is: %s.\n", objectName, principal)
 
 	// verify permission
 	effect, err = cli.IsObjectPermissionAllowed(ctx, principal, bucketName, objectName, permTypes.ACTION_DELETE_OBJECT)

--- a/examples/storage.go
+++ b/examples/storage.go
@@ -58,6 +58,8 @@ func main() {
 		bytes.NewReader(buffer.Bytes()), types.PutObjectOptions{TxnHash: txnHash})
 	handleErr(err, "PutObject")
 
+	log.Printf("object: %s has been uploaded to SP\n", objectName)
+
 	waitObjectSeal(cli, bucketName, objectName)
 
 	// get object
@@ -85,6 +87,7 @@ func main() {
 	if err != nil {
 		log.Fatalln("txn fail")
 	}
+	log.Printf("object: %s has been deleted\n", objectName)
 
 }
 

--- a/types/const.go
+++ b/types/const.go
@@ -46,5 +46,7 @@ const (
 	CreateObjectAction = "CreateObject"
 	CreateBucketAction = "CreateBucket"
 
-	ChallengeUrl = "challenge"
+	ChallengeUrl           = "challenge"
+	PrimaryRedundancyIndex = -1
+	MaxRedundancyIndex     = 5
 )

--- a/types/option.go
+++ b/types/option.go
@@ -185,6 +185,11 @@ type GetObjectOption struct {
 	Range string `url:"-" header:"Range,omitempty"` // support for downloading partial data
 }
 
+type GetChallengeInfoOptions struct {
+	Endpoint  string // indicates the endpoint of sp
+	SPAddress string // indicates the HEX-encoded string of the sp address to be challenged
+}
+
 func (o *GetObjectOption) SetRange(start, end int64) error {
 	switch {
 	case 0 < start && end == 0:


### PR DESCRIPTION
### Description


When challenging secondary sp, go sdk obtains the sp endpoint through the bucket name by default, not the secondary sp endpoint.

1) add options to pass the SP address or endpoint directly
2) if options is not provided , get the SP address by redanduncy index

### Rationale
 support getting challenge info from the secondary sp


### Example

```
cli.GetChallengeInfo(ctx, objectID,  0,  -1,  types.GetChallengeInfoOptions{SPAddress: "0x.."})
cli.GetChallengeInfo(ctx, objectID,  0,  -1,  types.GetChallengeInfoOptions{Endpoint: "https://gnfd-testnet-sp-1.nodereal.io"})
```

### Changes

Notable changes:
*  fix: support getting challenge info from the secondary sp
