### PR TITLE
fix:  config timeout to context in createObject and createBucket 

### DIFF
--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -154,12 +154,12 @@ func (c *client) CreateBucket(ctx context.Context, bucketName string, primaryAdd
 		return "", err
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, types.ContextTimeout)
-	defer cancel()
-
 	var txnResponse *sdk.TxResponse
 	txnHash := resp.TxResponse.TxHash
 	if !opts.IsAsyncMode {
+		ctxTimeout, cancel := context.WithTimeout(ctx, types.ContextTimeout)
+		defer cancel()
+
 		txnResponse, err = c.WaitForTx(ctxTimeout, txnHash)
 		if err != nil {
 			return txnHash, fmt.Errorf("the transaction has been submitted, please check it later:%v", err)

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -154,7 +154,7 @@ func (c *client) CreateBucket(ctx context.Context, bucketName string, primaryAdd
 		return "", err
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*30)
+	ctxTimeout, cancel := context.WithTimeout(ctx, types.ContextTimeout)
 	defer cancel()
 
 	var txnResponse *sdk.TxResponse

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	hashlib "github.com/bnb-chain/greenfield-common/go/hash"
 	gnfdsdk "github.com/bnb-chain/greenfield/sdk/types"
@@ -161,7 +160,7 @@ func (c *client) CreateObject(ctx context.Context, bucketName, objectName string
 		return "", err
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, time.Second*30)
+	ctxTimeout, cancel := context.WithTimeout(context.Background(), types.ContextTimeout)
 	defer cancel()
 
 	txnHash := resp.TxResponse.TxHash

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -160,12 +160,11 @@ func (c *client) CreateObject(ctx context.Context, bucketName, objectName string
 		return "", err
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(ctx, types.ContextTimeout)
-	defer cancel()
-
 	txnHash := resp.TxResponse.TxHash
 	var txnResponse *sdk.TxResponse
 	if !opts.IsAsyncMode {
+		ctxTimeout, cancel := context.WithTimeout(ctx, types.ContextTimeout)
+		defer cancel()
 		txnResponse, err = c.WaitForTx(ctxTimeout, txnHash)
 		if err != nil {
 			return txnHash, fmt.Errorf("the transaction has been submitted, please check it later:%v", err)

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -160,7 +160,7 @@ func (c *client) CreateObject(ctx context.Context, bucketName, objectName string
 		return "", err
 	}
 
-	ctxTimeout, cancel := context.WithTimeout(context.Background(), types.ContextTimeout)
+	ctxTimeout, cancel := context.WithTimeout(ctx, types.ContextTimeout)
 	defer cancel()
 
 	txnHash := resp.TxResponse.TxHash

--- a/types/const.go
+++ b/types/const.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"runtime"
+	"time"
 )
 
 const (
@@ -48,5 +49,6 @@ const (
 
 	ChallengeUrl           = "challenge"
 	PrimaryRedundancyIndex = -1
-	MaxRedundancyIndex     = 5
+
+	ContextTimeout = time.Second * 30
 )


### PR DESCRIPTION
### Description
config timeout for context which passed in waitForTxn of createObject and createBucket 

### Rationale

when txn failed and can not fetch info on chain. , this function will fall into infinite waiting and cannot exit 

### Example

NA

### Changes

Notable changes:
* config timeout to context