### PR TITLE
fix: parameter orders on example snippet on Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ func main() {
 
 	rpcAddr := "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443"
 	chainId := "greenfield_5600-1"
-	
-	gnfdCLient, err := client.New(rpcAddr, chainId, client.Option{DefaultAccount: account})
+	gnfdCLient, err := client.New(chainId, rpcAddr, client.Option{DefaultAccount: account})
 	if err != nil {
 		log.Fatalf("unable to new greenfield client, %v", err)
 	}


### PR DESCRIPTION
### Description

Parameter order has been changed on example code. 

### Rationale

Example was not working. client.New function's parameters has been changed on API side but forgotten on example.

### Example


### Changes

Notable changes:
* move chainId to first order