### PR TITLE
feat: list objects & buckets

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   GreenfieldTag: v0.2.3-alpha.1
-  GreenfieldStorageProviderTag: develop
+  GreenfieldStorageProviderTag: v0.2.3-alpha.1
   GOPRIVATE: github.com/bnb-chain
   GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
   MYSQL_USER: root

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -554,6 +554,8 @@ func (c *client) BuyQuotaForBucket(ctx context.Context, bucketName string, targe
 }
 
 // ListBucketsByBucketID list buckets by bucket ids
+// By inputting a collection of bucket IDs, we can retrieve the corresponding bucket data.
+// If the bucket is nonexistent or has been deleted, a null value will be returned
 func (c *client) ListBucketsByBucketID(ctx context.Context, bucketIds []uint64) (types.ListBucketsByBucketIDResponse, error) {
 	const MaximumListBucketsSize = 1000
 	if len(bucketIds) == 0 || len(bucketIds) > MaximumListBucketsSize {

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"encoding/hex"
 	"encoding/json"
@@ -59,6 +60,8 @@ type Bucket interface {
 
 	BuyQuotaForBucket(ctx context.Context, bucketName string, targetQuota uint64, opt types.BuyQuotaOption) (string, error)
 	GetBucketReadQuota(ctx context.Context, bucketName string) (types.QuotaInfo, error)
+	// ListBucketsByBucketID list buckets by bucket ids
+	ListBucketsByBucketID(ctx context.Context, bucketIds []uint64) (types.ListBucketsByBucketIDResponse, error)
 }
 
 // GetCreateBucketApproval returns the signature info for the approval of preCreating resources
@@ -548,4 +551,70 @@ func (c *client) BuyQuotaForBucket(ctx context.Context, bucketName string, targe
 	}
 
 	return resp.TxResponse.TxHash, err
+}
+
+// ListBucketsByBucketID list buckets by bucket ids
+func (c *client) ListBucketsByBucketID(ctx context.Context, bucketIds []uint64) (types.ListBucketsByBucketIDResponse, error) {
+	const MaximumListBucketsSize = 1000
+	if len(bucketIds) == 0 || len(bucketIds) > MaximumListBucketsSize {
+		return types.ListBucketsByBucketIDResponse{}, nil
+	}
+
+	objectIDMap := make(map[uint64]bool)
+	for _, id := range bucketIds {
+		if _, ok := objectIDMap[id]; ok {
+			// repeat id keys in request
+			return types.ListBucketsByBucketIDResponse{}, nil
+		}
+		objectIDMap[id] = true
+	}
+
+	params := url.Values{}
+	params.Set("buckets-query", "")
+
+	reqMeta := requestMeta{
+		urlValues:     params,
+		contentSHA256: types.EmptyStringSHA256,
+	}
+
+	b, err := json.Marshal(types.ObjectAndBucketIDs{IDs: bucketIds})
+	if err != nil {
+		return types.ListBucketsByBucketIDResponse{}, err
+	}
+
+	sendOpt := sendOptions{
+		method:           http.MethodPost,
+		body:             bytes.NewBuffer(b),
+		disableCloseBody: true,
+	}
+
+	endpoint, err := c.getInServiceSP()
+	if err != nil {
+		log.Error().Msg(fmt.Sprintf("get in-service SP fail %s", err.Error()))
+		return types.ListBucketsByBucketIDResponse{}, err
+	}
+
+	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, endpoint)
+	if err != nil {
+		return types.ListBucketsByBucketIDResponse{}, err
+	}
+	defer utils.CloseResponse(resp)
+
+	// unmarshal the json content from response body
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	if err != nil {
+		log.Error().Msgf("the list of buckets in bucket ids:%v failed: %s", bucketIds, err.Error())
+		return types.ListBucketsByBucketIDResponse{}, err
+	}
+
+	buckets := types.ListBucketsByBucketIDResponse{}
+	bufStr := buf.String()
+	err = json.Unmarshal([]byte(bufStr), &buckets)
+	if err != nil && buckets.Buckets == nil {
+		log.Error().Msgf("the list of buckets in bucket ids:%v failed: %s", bucketIds, err.Error())
+		return types.ListBucketsByBucketIDResponse{}, err
+	}
+
+	return buckets, nil
 }

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -80,6 +80,8 @@ type Object interface {
 	RecoverObjectBySecondary(ctx context.Context, bucketName, objectName, filePath string, opts types.GetObjectOptions) error
 	// GetObjectResumableUploadOffset return the status of the uploading object
 	GetObjectResumableUploadOffset(ctx context.Context, bucketName, objectName string) (uint64, error)
+	// ListObjectsByObjectID list objects by object ids
+	ListObjectsByObjectID(ctx context.Context, objectIds []uint64) (types.ListObjectsByObjectIDResponse, error)
 }
 
 // GetRedundancyParams query and return the data shards, parity shards and segment size of redundancy
@@ -1403,4 +1405,70 @@ func (c *client) UpdateObjectVisibility(ctx context.Context, bucketName, objectN
 	}
 
 	return c.sendTxn(ctx, updateObjectMsg, opt.TxOpts)
+}
+
+// ListObjectsByObjectID list objects by object ids
+func (c *client) ListObjectsByObjectID(ctx context.Context, objectIds []uint64) (types.ListObjectsByObjectIDResponse, error) {
+	const MaximumListObjectsSize = 1000
+	if len(objectIds) == 0 || len(objectIds) > MaximumListObjectsSize {
+		return types.ListObjectsByObjectIDResponse{}, nil
+	}
+
+	objectIDMap := make(map[uint64]bool)
+	for _, id := range objectIds {
+		if _, ok := objectIDMap[id]; ok {
+			// repeat id keys in request
+			return types.ListObjectsByObjectIDResponse{}, nil
+		}
+		objectIDMap[id] = true
+	}
+
+	params := url.Values{}
+	params.Set("objects-query", "")
+
+	reqMeta := requestMeta{
+		urlValues:     params,
+		contentSHA256: types.EmptyStringSHA256,
+	}
+
+	b, err := json.Marshal(types.ObjectAndBucketIDs{IDs: objectIds})
+	if err != nil {
+		return types.ListObjectsByObjectIDResponse{}, err
+	}
+
+	sendOpt := sendOptions{
+		method:           http.MethodPost,
+		body:             bytes.NewBuffer(b),
+		disableCloseBody: true,
+	}
+
+	endpoint, err := c.getInServiceSP()
+	if err != nil {
+		log.Error().Msg(fmt.Sprintf("get in-service SP fail %s", err.Error()))
+		return types.ListObjectsByObjectIDResponse{}, err
+	}
+
+	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, endpoint)
+	if err != nil {
+		return types.ListObjectsByObjectIDResponse{}, err
+	}
+	defer utils.CloseResponse(resp)
+
+	// unmarshal the json content from response body
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	if err != nil {
+		log.Error().Msgf("the list of objects in object ids:%v failed: %s", objectIds, err.Error())
+		return types.ListObjectsByObjectIDResponse{}, err
+	}
+
+	objects := types.ListObjectsByObjectIDResponse{}
+	bufStr := buf.String()
+	err = json.Unmarshal([]byte(bufStr), &objects)
+	if err != nil && objects.Objects == nil {
+		log.Error().Msgf("the list of objects in object ids:%v failed: %s", objectIds, err.Error())
+		return types.ListObjectsByObjectIDResponse{}, err
+	}
+
+	return objects, nil
 }

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -1408,6 +1408,8 @@ func (c *client) UpdateObjectVisibility(ctx context.Context, bucketName, objectN
 }
 
 // ListObjectsByObjectID list objects by object ids
+// By inputting a collection of object IDs, we can retrieve the corresponding object data.
+// If the object is nonexistent or has been deleted, a null value will be returned
 func (c *client) ListObjectsByObjectID(ctx context.Context, objectIds []uint64) (types.ListObjectsByObjectIDResponse, error) {
 	const MaximumListObjectsSize = 1000
 	if len(objectIds) == 0 || len(objectIds) > MaximumListObjectsSize {

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -168,7 +168,7 @@ func (s *StorageTestSuite) Test_Object() {
 		bytes.NewReader(buffer.Bytes()), types.PutObjectOptions{})
 	s.Require().NoError(err)
 
-	time.Sleep(10 * time.Second)
+	time.Sleep(20 * time.Second)
 	objectInfo, err = s.Client.HeadObject(s.ClientContext, bucketName, objectName)
 	s.Require().NoError(err)
 	if err == nil {

--- a/examples/storage.go
+++ b/examples/storage.go
@@ -80,6 +80,25 @@ func main() {
 		log.Printf("object: %s, status: %s\n", i.ObjectName, i.ObjectStatus)
 	}
 
+	// list object by object ids
+	ids := []uint64{1, 2, 333}
+	objects2, err := cli.ListObjectsByObjectID(ctx, ids)
+	log.Printf("list objects by ids result: %v\n", objects2)
+	for _, object := range objects2.Objects {
+		if object != nil {
+			log.Printf("object: %s, status: %s\n", object.ObjectInfo.ObjectName, object.ObjectInfo.ObjectStatus)
+		}
+	}
+
+	// list buckets by bucket ids
+	buckets, err := cli.ListBucketsByBucketID(ctx, ids)
+	log.Printf("list buckets by ids result: %v\n", buckets)
+	for _, bucket := range buckets.Buckets {
+		if bucket != nil {
+			log.Printf("bucket: %s, status: %s\n", bucket.BucketInfo.BucketName, bucket.BucketInfo.BucketStatus)
+		}
+	}
+
 }
 
 func waitObjectSeal(cli client.Client, bucketName, objectName string) {

--- a/types/list.go
+++ b/types/list.go
@@ -98,6 +98,17 @@ type ObjectMeta struct {
 	SealTxHash string `json:"seal_tx_hash"`
 }
 
+// ListObjectsByObjectIDResponse is response type for the ListObjectsByObjectID
+type ListObjectsByObjectIDResponse struct {
+	// objects defines the information of a object map
+	Objects map[uint64]*ObjectMeta `json:"objects"`
+}
+
+// ObjectAndBucketIDs is the structure for ListBucketsByBucketID & ListObjectsByObjectID request body
+type ObjectAndBucketIDs struct {
+	IDs []uint64 `json:"ids"`
+}
+
 // BucketMeta is the structure for metadata service user bucket
 type BucketMeta struct {
 	// bucket_info defines the information of the bucket.
@@ -176,6 +187,12 @@ type BucketInfo struct {
 	BillingInfo storageType.BillingInfo `json:"billing_info"`
 	// bucket_status define the status of the bucket.
 	BucketStatus storageType.BucketStatus `json:"bucket_status"`
+}
+
+// ListBucketsByBucketIDResponse is response type for the ListBucketsByBucketID
+type ListBucketsByBucketIDResponse struct {
+	// buckets defines the information of a bucket map
+	Buckets map[uint64]*BucketMeta `json:"buckets"`
 }
 
 // GroupMeta is the structure for group information


### PR DESCRIPTION
### Description

support list objects by id and list buckets by id

### Rationale

N/A

### Example

```
curl --location --request POST 'localhost:9133/?objects-query' \
--header 'Authorization: authTypeV2 ECDSA-secp256k1, Signature=1234567812345678123456781234567812345678123456781234567812345678' \
--header 'Content-Type: application/json' \
--data-raw '{
    "ids": [333,666]
}'
```

```
curl --location --request POST 'localhost:9133/?buckets-query' \
--header 'Authorization: authTypeV2 ECDSA-secp256k1, Signature=1234567812345678123456781234567812345678123456781234567812345678' \
--header 'Content-Type: application/json' \
--data-raw '{
    "ids": [222]
}'
```


### Changes

Notable changes: 
* support list objects by id and list buckets by id