### PR TITLE
feat:  support recovery in client

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   GreenfieldTag: v0.2.2
-  GreenfieldStorageProviderTag: feat-data-recovery
+  GreenfieldStorageProviderTag: develop
   GOPRIVATE: github.com/bnb-chain
   GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
   MYSQL_USER: root

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   GreenfieldTag: v0.2.2
-  GreenfieldStorageProviderTag: v0.2.2
+  GreenfieldStorageProviderTag: feat-data-recovery
   GOPRIVATE: github.com/bnb-chain
   GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
   MYSQL_USER: root

--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -53,7 +53,7 @@ func (c *client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 	reqMeta := requestMeta{
 		urlRelPath:    types.ChallengeUrl,
 		contentSHA256: types.EmptyStringSHA256,
-		challengeInfo: types.ChallengeInfo{
+		pieceInfo: types.QueryPieceInfo{
 			ObjectId:        objectID,
 			PieceIndex:      pieceIndex,
 			RedundancyIndex: redundancyIndex,

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -314,7 +314,7 @@ func (c *client) newRequest(ctx context.Context, method string, meta requestMeta
 	// if pieceInfo.ObjectId is not empty, other field should be set as well
 	if meta.pieceInfo.ObjectId != "" {
 		info := meta.pieceInfo
-		req.Header.Set(types.HTTPHeaderObjectId, info.ObjectId)
+		req.Header.Set(types.HTTPHeaderObjectID, info.ObjectId)
 		req.Header.Set(types.HTTPHeaderRedundancyIndex, strconv.Itoa(info.RedundancyIndex))
 		req.Header.Set(types.HTTPHeaderPieceIndex, strconv.Itoa(info.PieceIndex))
 	}

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -217,8 +217,9 @@ type requestMeta struct {
 	contentLength    int64
 	contentMD5Base64 string // base64 encoded md5sum
 	contentSHA256    string // hex encoded sha256sum
-	challengeInfo    types.ChallengeInfo
+	pieceInfo        types.QueryPieceInfo
 	userAddress      string
+	segmentIndex     int
 }
 
 // SendOptions -  options to use to send the http message
@@ -311,20 +312,18 @@ func (c *client) newRequest(ctx context.Context, method string, meta requestMeta
 		req.Header.Set(types.HTTPHeaderRange, meta.rangeInfo)
 	}
 
-	if isAdminAPi {
-		// set challenge headers
-		// if challengeInfo.ObjectId is not empty, other field should be set as well
-		if meta.challengeInfo.ObjectId != "" {
-			info := meta.challengeInfo
-			req.Header.Set(types.HTTPHeaderObjectId, info.ObjectId)
-			req.Header.Set(types.HTTPHeaderRedundancyIndex, strconv.Itoa(info.RedundancyIndex))
-			req.Header.Set(types.HTTPHeaderPieceIndex, strconv.Itoa(info.PieceIndex))
-		}
+	// if pieceInfo.ObjectId is not empty, other field should be set as well
+	if meta.pieceInfo.ObjectId != "" {
+		info := meta.pieceInfo
+		req.Header.Set(types.HTTPHeaderObjectId, info.ObjectId)
+		req.Header.Set(types.HTTPHeaderRedundancyIndex, strconv.Itoa(info.RedundancyIndex))
+		req.Header.Set(types.HTTPHeaderPieceIndex, strconv.Itoa(info.PieceIndex))
+	}
 
+	if isAdminAPi {
 		if meta.txnMsg != "" {
 			req.Header.Set(types.HTTPHeaderUnsignedMsg, meta.txnMsg)
 		}
-
 	} else {
 		// set request host
 		if c.host != "" {

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -219,7 +219,6 @@ type requestMeta struct {
 	contentSHA256    string // hex encoded sha256sum
 	pieceInfo        types.QueryPieceInfo
 	userAddress      string
-	segmentIndex     int
 }
 
 // SendOptions -  options to use to send the http message

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -513,9 +513,9 @@ func checkGetObjectRange(payloadSize uint64, maxSegmentSize uint64, opts types.G
 		startSegmentIdx      int
 		endSegmentIdx        int
 	)
-	segmentCount := int(utils.GetSegmentCount(payloadSize, maxSegmentSize) - 1)
+	segmentCount := utils.GetSegmentCount(payloadSize, maxSegmentSize)
 	if opts.Range == "" {
-		return 0, segmentCount - 1, 0, 0, nil
+		return 0, int(segmentCount - 1), 0, 0, nil
 	}
 
 	isRange, rangeStart, rangeEnd := utils.ParseRange(rangeInfo)
@@ -535,7 +535,7 @@ func checkGetObjectRange(payloadSize uint64, maxSegmentSize uint64, opts types.G
 		diffEndOffset = int(rangeEnd - int64(endSegmentIdx)*int64(maxSegmentSize))
 	} else {
 		startSegmentIdx = 0
-		endSegmentIdx = segmentCount
+		endSegmentIdx = int(segmentCount - 1)
 	}
 
 	return startSegmentIdx, endSegmentIdx, diffStartOffset, diffEndOffset, nil
@@ -549,7 +549,6 @@ func (c *client) getSecondaryEndpoints(ctx context.Context, objectInfo *storageT
 	}
 
 	secondaryEndpointList := make([]string, len(secondarySPAddrs))
-
 	for idx, addr := range secondarySPAddrs {
 		for _, info := range spList {
 			if addr == info.GetOperatorAddress() {

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -446,7 +446,6 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 					PieceIndex:      segmentIdx,
 					RedundancyIndex: secondaryIndex,
 				}
-				fmt.Printf("send request to sp: %s, index %d ,\n", secondaryEndpoints[secondaryIndex], secondaryIndex)
 				// call getSecondaryPieceData to retrieve recovery data for the segment
 				responseBody, err = c.getSecondaryPieceData(ctx, bucketName, objectName, pieceInfo, types.GetSecondaryPieceOptions{Endpoint: secondaryEndpoints[secondaryIndex]})
 				if err == nil {
@@ -457,7 +456,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 						return
 					}
 					recoveryDataSources[secondaryIndex] = pieceData
-					//	fmt.Printf("get one piece from sp: %s , piece length:%d \n", secondaryEndpoints[secondaryIndex], len(pieceData))
+					fmt.Printf("get one piece from sp: %s , piece length:%d \n", secondaryEndpoints[secondaryIndex], len(pieceData))
 					doneCh <- true
 				} else {
 					log.Error().Msg("get piece from secondary SP error:" + err.Error())
@@ -482,6 +481,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 			}
 		}
 
+		fmt.Printf("to recovery segment len:%d, index:%d,\n", segmentSize, segmentIdx)
 		// decode the original segment data from the piece data
 		recoverySegData, err := redundancy.DecodeRawSegment(recoveryDataSources, segmentSize, int(dataBlocks), int(parityBlocks))
 		if err != nil {
@@ -539,7 +539,7 @@ func checkGetObjectRange(payloadSize uint64, maxSegmentSize uint64, opts types.G
 
 		endSegmentIdx = int(rangeEnd / int64(maxSegmentSize))
 		endSegSize := utils.GetSegmentSize(payloadSize, uint32(endSegmentIdx), maxSegmentSize)
-		diffEndOffset = int64(endSegmentIdx)*int64(maxSegmentSize) + endSegSize - rangeEnd
+		diffEndOffset = int64(endSegmentIdx)*int64(maxSegmentSize) + endSegSize - rangeEnd - 1
 
 		if diffEndOffset > endSegSize {
 			log.Error().Msg("compute end segment diff offset error ")

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -415,6 +415,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 	var recoveryDataSources = make([][]byte, len(secondaryEndpoints))
 	segmentCount := utils.GetSegmentCount(objectInfo.PayloadSize, maxSegmentSize)
 	// iterate over segment indices and recover one by one
+	totalTaskNum := int32(ecPieceCount)
 	for segmentIdx := 0; segmentIdx < int(segmentCount); segmentIdx++ {
 		doneCh := make(chan bool, len(secondaryEndpoints))
 		quitCh := make(chan bool)
@@ -425,7 +426,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 				defer func() {
 					fmt.Printf("get done routine: %d \n", atomic.LoadUint32(&ecPieceCount))
 					// finish all the task, send signal to quitCh
-					if atomic.AddUint32(&ecPieceCount, -1) == 0 {
+					if atomic.AddInt32(&totalTaskNum, -1) == 0 {
 						quitCh <- true
 					}
 				}()

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -433,9 +433,9 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 				pieceInfo := types.QueryPieceInfo{
 					ObjectId:        strconv.FormatUint(objectInfo.Id.Uint64(), 10),
 					PieceIndex:      segmentIdx,
-					RedundancyIndex: ecIdx,
+					RedundancyIndex: secondaryIndex,
 				}
-				fmt.Printf("send request to sp: %s, index %d ,\n", secondaryEndpoints[secondaryIndex], ecIdx)
+				fmt.Printf("send request to sp: %s, index %d ,\n", secondaryEndpoints[secondaryIndex], secondaryIndex)
 				// call getSecondaryPieceData to retrieve recovery data for the segment
 				resBody, err := c.getSecondaryPieceData(ctx, bucketName, objectName, pieceInfo, types.GetSecondaryPieceOptions{Endpoint: secondaryEndpoints[secondaryIndex]})
 				if err == nil {

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -31,7 +31,6 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/rs/zerolog/log"
-	"google.golang.org/genproto/googleapis/api/visibility"
 )
 
 type Object interface {
@@ -413,7 +412,6 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 		return err
 	}
 
-
 	_, err = os.Stat(filePath)
 	if err == nil {
 		return errors.New("download file already exist:" + filePath)
@@ -490,7 +488,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 					return fmt.Errorf("get piece from secondary not enough %d", doneTaskNum)
 				}
 				ecTotalSize := int64(uint32(downLoadPieceSize) * dataBlocks)
-				if ecTotalSize  < segmentSize || ecTotalSize > segmentSize+4{
+				if ecTotalSize < segmentSize || ecTotalSize > segmentSize+4 {
 					return fmt.Errorf("get secondary piece data length error")
 				}
 			}
@@ -504,13 +502,13 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 			return fmt.Errorf("decode segment err, segment id:%d err: %s", segmentIdx, err.Error())
 		}
 
-		fmt.Printf("recovery one segment , piece length:%d ", len(recoverySegData)
+		fmt.Printf("recovery one segment , piece length:%d ", len(recoverySegData))
 		isFirstSeg := segmentIdx == startSegmentIdx && diffStartOffset > 0
 		isLastSeg := segmentIdx == endSegmentIdx && diffEndOffset > 0
 
 		// deal with range recovery
 		if isFirstSeg && isLastSeg {
-			recoverySegData = recoverySegData[diffStartOffset:segmentSize-diffEndOffset]
+			recoverySegData = recoverySegData[diffStartOffset : segmentSize-diffEndOffset]
 		} else if isFirstSeg {
 			recoverySegData = recoverySegData[diffStartOffset:]
 			log.Printf("first segment diff offset %d \n", diffStartOffset)

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -412,7 +412,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 	defer f.Close()
 
 	doneTaskNum := uint32(0)
-	var recoveryDataSources = make([][]byte, len(secondaryEndpoints))
+	var recoveryDataSources = make([][]byte, ecPieceCount)
 	segmentCount := utils.GetSegmentCount(objectInfo.PayloadSize, maxSegmentSize)
 	// iterate over segment indices and recover one by one
 	totalTaskNum := int32(ecPieceCount)
@@ -497,11 +497,10 @@ func (c *client) getSecondaryEndpoints(ctx context.Context, objectInfo *storageT
 
 	secondaryEndpointList := make([]string, len(secondarySPAddrs))
 
-	for _, addr := range secondarySPAddrs {
+	for idx, addr := range secondarySPAddrs {
 		for _, info := range spList {
 			if addr == info.GetOperatorAddress() {
-				secondaryEndpointList = append(secondaryEndpointList, info.Endpoint)
-				fmt.Printf("get seondary sp: %s \n", secondaryEndpointList)
+				secondaryEndpointList[idx] = info.Endpoint
 			}
 		}
 	}

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -520,7 +520,7 @@ func checkGetObjectRange(payloadSize uint64, maxSegmentSize uint64, opts types.G
 
 	isRange, rangeStart, rangeEnd := utils.ParseRange(rangeInfo)
 	if isRange && (rangeEnd < 0 || rangeEnd >= int64(payloadSize)) {
-		return 0, 0, 0, 0, errors.New("invalid range: " + rangeInfo)
+		rangeEnd = int64(payloadSize) - 1
 	}
 
 	if isRange && (rangeStart < 0 || rangeEnd < 0 || rangeStart > rangeEnd) {
@@ -532,7 +532,7 @@ func checkGetObjectRange(payloadSize uint64, maxSegmentSize uint64, opts types.G
 		diffStartOffset = int(rangeStart - int64(startSegmentIdx)*int64(maxSegmentSize))
 
 		endSegmentIdx = int(rangeEnd / int64(maxSegmentSize))
-		diffEndOffset = int(rangeEnd - int64(endSegmentIdx)*int64(maxSegmentSize))
+		diffEndOffset = int(int64(endSegmentIdx+1)*int64(maxSegmentSize) - rangeEnd)
 	} else {
 		startSegmentIdx = 0
 		endSegmentIdx = int(segmentCount - 1)

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -438,7 +438,6 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 				fmt.Printf("send request to sp: %s, index %d ,\n", secondaryEndpoints[secondaryIndex], ecIdx)
 				// call getSecondaryPieceData to retrieve recovery data for the segment
 				resBody, err := c.getSecondaryPieceData(ctx, bucketName, objectName, pieceInfo, types.GetSecondaryPieceOptions{Endpoint: secondaryEndpoints[secondaryIndex]})
-				defer resBody.Close()
 				if err == nil {
 					// convert recoveryData to byte
 					pieceData, err := io.ReadAll(resBody)
@@ -450,6 +449,8 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 					fmt.Printf("get one piece from sp: %s , piece length:%d \n", secondaryEndpoints[secondaryIndex], len(pieceData))
 					doneCh <- true
 				}
+				log.Error().Msg("get piece from secondary SP error:" + err.Error())
+				defer resBody.Close()
 
 			}(ecIdx)
 

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -533,6 +533,7 @@ func checkGetObjectRange(payloadSize uint64, maxSegmentSize uint64, opts types.G
 
 		endSegmentIdx = int(rangeEnd / int64(maxSegmentSize))
 		diffEndOffset = int(int64(endSegmentIdx+1)*int64(maxSegmentSize) - rangeEnd)
+		log.Printf("startSet %d, diffStartOffset %d,  endSegmentIdx %d, diffEndOffset %d,", startSegmentIdx, diffStartOffset, endSegmentIdx, diffEndOffset)
 	} else {
 		startSegmentIdx = 0
 		endSegmentIdx = int(segmentCount - 1)

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -400,7 +400,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 		return err
 	}
 
-	secondaryEndpoints, err := c.getSecondaryEndpoints(ctx, objectInfo, int(ecPieceCount))
+	secondaryEndpoints, err := c.getSecondaryEndpoints(ctx, objectInfo)
 	if err != nil {
 		return err
 	}
@@ -443,6 +443,7 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 						return
 					}
 					recoveryDataSources[secondaryIndex] = pieceData
+					fmt.Printf("get one piece from sp: %s , piece length:%d \n", secondaryEndpoints[secondaryIndex], len(pieceData))
 					doneCh <- true
 				}
 				defer resBody.Close()

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -360,14 +360,9 @@ func (c *client) FGetObject(ctx context.Context, bucketName, objectName, filePat
 	if err == nil {
 		// If the destination exists and is a directory.
 		if st.IsDir() {
-			return errors.New("fileName is a directory.")
+			return errors.New("download file path is a directory")
 		}
-	}
-
-	// If file exist, open it in append mode
-	fd, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o660)
-	if err != nil {
-		return err
+		return errors.New("download file already exist")
 	}
 
 	backoffDelay := types.DownloadBackOffDelay
@@ -395,6 +390,12 @@ func (c *client) FGetObject(ctx context.Context, bucketName, objectName, filePat
 	}
 
 	defer body.Close()
+
+	fd, err := os.OpenFile(filePath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o660)
+	if err != nil {
+		return err
+	}
+	
 	_, err = io.Copy(fd, body)
 	fd.Close()
 	if err != nil {

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -470,23 +470,18 @@ func (c *client) RecoverObjectBySecondary(ctx context.Context, bucketName, objec
 
 			recoverySegData, err := redundancy.DecodeRawSegment(recoveryDataSources, segmentSize, int(dataBlocks), int(parityBlocks))
 			if err != nil {
+				log.Error().Msg(fmt.Sprintf("decode segment err, segment id:%d err: %s", segmentIdx, err.Error()))
 				return fmt.Errorf("decode segment err, segment id:%d err: %s", segmentIdx, err.Error())
 			}
-			// append recoverySegData to the file specified by filePath
-			f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
-			if err != nil {
-				return err
-			}
-			defer f.Close()
 
 			_, err = f.Write(recoverySegData)
 			if err != nil {
 				return err
 			}
+			log.Printf(fmt.Sprintf("finish recovery object:%s segment id:%d ", objectName, segmentIdx))
 		}
 	}
 
-	// return any necessary error or nil if successful
 	return nil
 }
 

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -198,6 +198,27 @@ func (s *StorageTestSuite) Test_Object() {
 		s.Require().Equal(content, buffer.Bytes())
 	}
 
+	s.T().Log("---> RecoveryObject Range <---")
+	filePath = "downloadfileRange"
+	opt := types.GetObjectOption{}
+	rangeStart := 100 * 2024
+	rangeEnd := 10 * 1024 * 1024
+	err = opt.SetRange(int64(rangeStart), int64(rangeEnd))
+	s.Require().NoError(err)
+	err = s.Client.RecoverObjectBySecondary(s.ClientContext, bucketName, objectName, filePath, opt)
+	s.Require().NoError(err)
+	if err == nil {
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			fmt.Println("can not read download file:", err)
+			return
+		}
+
+		s.Require().NoError(err)
+		originalBytes := buffer.Bytes()[rangeStart:rangeEnd]
+		s.Require().Equal(content, originalBytes)
+	}
+
 	s.T().Log("---> PutObjectPolicy <---")
 	principal, _, err := types.NewAccount("principal")
 	s.Require().NoError(err)

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -216,8 +216,16 @@ func (s *StorageTestSuite) Test_Object() {
 
 		fmt.Println("read recovery length:", len(content), "range len:", rangeEnd-rangeStart+1)
 		s.Require().NoError(err)
-		originalBytes := buffer.Bytes()[rangeStart:rangeEnd]
-		s.Require().Equal(content, originalBytes)
+		//	originalBytes := buffer.Bytes()[rangeStart:rangeEnd]
+		//	s.Require().Equal(content, originalBytes)
+		ior, _, err = s.Client.GetObject(s.ClientContext, bucketName, objectName, opt)
+		s.Require().NoError(err)
+		if err == nil {
+			objectBytes, err := io.ReadAll(ior)
+			s.Require().NoError(err)
+			s.Require().Equal(objectBytes, content)
+			fmt.Println("read download len length:", len(objectBytes))
+		}
 	}
 
 	s.T().Log("---> PutObjectPolicy <---")

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 	"time"
 
@@ -188,7 +188,7 @@ func (s *StorageTestSuite) Test_Object() {
 	err = s.Client.RecoverObjectBySecondary(s.ClientContext, bucketName, objectName, filePath, types.GetObjectOption{})
 	s.Require().NoError(err)
 	if err == nil {
-		content, err := ioutil.ReadFile(filePath)
+		content, err := os.ReadFile(filePath)
 		if err != nil {
 			fmt.Println("can not read download file:", err)
 			return

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -174,7 +174,7 @@ func (s *StorageTestSuite) Test_Object() {
 		s.Require().Equal(objectInfo.GetObjectStatus().String(), "OBJECT_STATUS_SEALED")
 	}
 
-	ior, info, err := s.Client.GetObject(s.ClientContext, bucketName, objectName, types.GetObjectOption{})
+	ior, info, err := s.Client.GetObject(s.ClientContext, bucketName, objectName, types.GetObjectOptions{})
 	s.Require().NoError(err)
 	if err == nil {
 		s.Require().Equal(info.ObjectName, objectName)
@@ -185,7 +185,7 @@ func (s *StorageTestSuite) Test_Object() {
 
 	s.T().Log("---> RecoveryObject <---")
 	filePath := "downloadfile"
-	err = s.Client.RecoverObjectBySecondary(s.ClientContext, bucketName, objectName, filePath, types.GetObjectOption{})
+	err = s.Client.RecoverObjectBySecondary(s.ClientContext, bucketName, objectName, filePath, types.GetObjectOptions{})
 	s.Require().NoError(err)
 	if err == nil {
 		content, err := os.ReadFile(filePath)
@@ -200,7 +200,7 @@ func (s *StorageTestSuite) Test_Object() {
 
 	s.T().Log("---> RecoveryObject Range <---")
 	filePath = "downloadfileRange"
-	opt := types.GetObjectOption{}
+	opt := types.GetObjectOptions{}
 	rangeStart := 100 * 2024
 	rangeEnd := 10 * 1024 * 1024
 	err = opt.SetRange(int64(rangeStart), int64(rangeEnd))

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -144,9 +144,9 @@ func (s *StorageTestSuite) Test_Object() {
 	}
 
 	var buffer bytes.Buffer
-	line := `1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890`
+	line := `1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,123456789012`
 	// Create 1MiB content where each line contains 1024 characters.
-	for i := 0; i < 1024*100; i++ {
+	for i := 0; i < 1024*300; i++ {
 		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
 	}
 

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -214,6 +214,7 @@ func (s *StorageTestSuite) Test_Object() {
 			return
 		}
 
+		fmt.Println("read recovery length:", len(content), "range len:", rangeEnd-rangeStart+1)
 		s.Require().NoError(err)
 		originalBytes := buffer.Bytes()[rangeStart:rangeEnd]
 		s.Require().Equal(content, originalBytes)

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -180,6 +181,21 @@ func (s *StorageTestSuite) Test_Object() {
 		objectBytes, err := io.ReadAll(ior)
 		s.Require().NoError(err)
 		s.Require().Equal(objectBytes, buffer.Bytes())
+	}
+
+	s.T().Log("---> RecoveryObject <---")
+	filePath := "downloadfile"
+	err = s.Client.RecoverObjectBySecondary(s.ClientContext, bucketName, objectName, filePath, types.GetObjectOption{})
+	s.Require().NoError(err)
+	if err == nil {
+		content, err := ioutil.ReadFile(filePath)
+		if err != nil {
+			fmt.Println("can not read download file:", err)
+			return
+		}
+
+		s.Require().NoError(err)
+		s.Require().Equal(content, buffer.Bytes())
 	}
 
 	s.T().Log("---> PutObjectPolicy <---")

--- a/examples/storage.go
+++ b/examples/storage.go
@@ -63,7 +63,7 @@ func main() {
 	waitObjectSeal(cli, bucketName, objectName)
 
 	// get object
-	reader, info, err := cli.GetObject(ctx, bucketName, objectName, types.GetObjectOption{})
+	reader, info, err := cli.GetObject(ctx, bucketName, objectName, types.GetObjectOptions{})
 	handleErr(err, "GetObject")
 	log.Printf("get object %s successfully, size %d \n", info.ObjectName, info.Size)
 	handleErr(err, "GetObject")
@@ -79,7 +79,7 @@ func main() {
 		i := obj.ObjectInfo
 		log.Printf("object: %s, status: %s\n", i.ObjectName, i.ObjectStatus)
 	}
-	
+
 }
 
 func waitObjectSeal(cli client.Client, bucketName, objectName string) {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -242,3 +242,45 @@ func GetSegmentCount(payloadSize uint64, maxSegmentSize uint64) uint32 {
 	}
 	return uint32(count)
 }
+
+func ParseRange(rangeStr string) (bool, int64, int64) {
+	if rangeStr == "" {
+		return false, -1, -1
+	}
+	rangeStr = strings.ToLower(rangeStr)
+	rangeStr = strings.ReplaceAll(rangeStr, " ", "")
+	if !strings.HasPrefix(rangeStr, "bytes=") {
+		return false, -1, -1
+	}
+	rangeStr = rangeStr[len("bytes="):]
+	if strings.HasSuffix(rangeStr, "-") {
+		rangeStr = rangeStr[:len(rangeStr)-1]
+		rangeStart, err := stringToUint64(rangeStr)
+		if err != nil {
+			return false, -1, -1
+		}
+		return true, int64(rangeStart), -1
+	}
+	pair := strings.Split(rangeStr, "-")
+	if len(pair) == 2 {
+		rangeStart, err := stringToUint64(pair[0])
+		if err != nil {
+			return false, -1, -1
+		}
+		rangeEnd, err := stringToUint64(pair[1])
+		if err != nil {
+			return false, -1, -1
+		}
+		return true, int64(rangeStart), int64(rangeEnd)
+	}
+	return false, -1, -1
+}
+
+// StringToUint64 converts string to uint64
+func stringToUint64(str string) (uint64, error) {
+	ui64, err := strconv.ParseUint(str, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return ui64, nil
+}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -210,3 +210,35 @@ func IsValidObjectPrefix(prefix string) bool {
 	}
 	return true
 }
+
+func GetSegmentSize(payloadSize uint64, segmentIdx uint32, maxSegmentSize uint64) int64 {
+	segmentCount := GetSegmentCount(payloadSize, maxSegmentSize)
+	if segmentCount == 1 {
+		return int64(payloadSize)
+	} else if segmentIdx == segmentCount-1 {
+		return int64(payloadSize) - (int64(segmentCount)-1)*int64(maxSegmentSize)
+	} else {
+		return int64(maxSegmentSize)
+	}
+}
+
+func GetECPieceSize(payloadSize uint64, segmentIdx uint32, maxSegmentSize uint64, dataChunkNum uint32) int64 {
+	segmentSize := GetSegmentSize(payloadSize, segmentIdx, maxSegmentSize)
+
+	pieceSize := segmentSize / int64(dataChunkNum)
+	// EC padding will cause the EC pieces to have one extra byte if it cannot be evenly divided.
+	// for example, the segment size is 15, the ec piece size should be 15/4 + 1 = 4
+	if segmentSize > 0 && segmentSize%int64(dataChunkNum) != 0 {
+		pieceSize++
+	}
+
+	return pieceSize
+}
+
+func GetSegmentCount(payloadSize uint64, maxSegmentSize uint64) uint32 {
+	count := payloadSize / maxSegmentSize
+	if payloadSize%maxSegmentSize > 0 {
+		count++
+	}
+	return uint32(count)
+}

--- a/types/const.go
+++ b/types/const.go
@@ -22,7 +22,7 @@ const (
 	HTTPHeaderSignedMsg       = "X-Gnfd-Signed-Msg"
 	HTTPHeaderPieceIndex      = "X-Gnfd-Piece-Index"
 	HTTPHeaderRedundancyIndex = "X-Gnfd-Redundancy-Index"
-	HTTPHeaderObjectId        = "X-Gnfd-Object-ID"
+	HTTPHeaderObjectID        = "X-Gnfd-Object-ID"
 	HTTPHeaderIntegrityHash   = "X-Gnfd-Integrity-Hash"
 	HTTPHeaderPieceHash       = "X-Gnfd-Piece-Hash"
 

--- a/types/const.go
+++ b/types/const.go
@@ -54,4 +54,6 @@ const (
 	MaxHeadTryTime   = 4
 	HeadBackOffDelay = time.Millisecond * 500
 	NoSuchObjectErr  = "no such object"
+
+	GetConnectionFail = "connection refused"
 )

--- a/types/const.go
+++ b/types/const.go
@@ -56,4 +56,7 @@ const (
 	NoSuchObjectErr  = "no such object"
 
 	GetConnectionFail = "connection refused"
+
+	MaxDownloadTryTime   = 3
+	DownloadBackOffDelay = time.Millisecond * 500
 )

--- a/types/option.go
+++ b/types/option.go
@@ -188,7 +188,7 @@ type PutObjectOptions struct {
 // GetObjectOptions contains the options of getObject
 type GetObjectOptions struct {
 	Range           string `url:"-" header:"Range,omitempty"` // support for downloading partial data
-	SupportRecovery bool
+	SupportRecovery bool   // support recover data from secondary SPs if primary SP not in service
 }
 
 type GetChallengeInfoOptions struct {

--- a/types/option.go
+++ b/types/option.go
@@ -195,6 +195,11 @@ type GetChallengeInfoOptions struct {
 	SPAddress string // indicates the HEX-encoded string of the sp address to be challenged
 }
 
+type GetSecondaryPieceOptions struct {
+	Endpoint  string // indicates the endpoint of sp
+	SPAddress string // indicates the HEX-encoded string of the sp address to be challenged
+}
+
 type ListGroupsOptions struct {
 	SourceType string
 	Limit      int64

--- a/types/option.go
+++ b/types/option.go
@@ -185,9 +185,10 @@ type PutObjectOptions struct {
 	TxnHash     string
 }
 
-// GetObjectOption contains the options of getObject
-type GetObjectOption struct {
-	Range string `url:"-" header:"Range,omitempty"` // support for downloading partial data
+// GetObjectOptions contains the options of getObject
+type GetObjectOptions struct {
+	Range           string `url:"-" header:"Range,omitempty"` // support for downloading partial data
+	SupportRecovery bool
 }
 
 type GetChallengeInfoOptions struct {
@@ -206,7 +207,7 @@ type ListGroupsOptions struct {
 	Offset     int64
 }
 
-func (o *GetObjectOption) SetRange(start, end int64) error {
+func (o *GetObjectOptions) SetRange(start, end int64) error {
 	switch {
 	case 0 < start && end == 0:
 		// `bytes=N-`.

--- a/types/types.go
+++ b/types/types.go
@@ -15,10 +15,10 @@ type ObjectStat struct {
 	Size        int64
 }
 
-// ChallengeInfo indicates the challenge object info
+// QueryPieceInfo indicates the challenge or recovery object piece info
 // RedundancyIndex if it is primary sp, the value should be -1，
 // else it indicates the index of secondary sp
-type ChallengeInfo struct {
+type QueryPieceInfo struct {
 	ObjectId        string
 	PieceIndex      int
 	RedundancyIndex int


### PR DESCRIPTION
### Description

<img width="971" alt="image" src="https://github.com/bnb-chain/greenfield-go-sdk/assets/19421226/c4d859e7-cd54-45c3-913a-a1fe26b4be62">


if primary SP not in service , the  client can get piece data from secondary SP and decode the origin segment.

Client.RecoverObjectBySecondary support same option as getObject to support range recovery

### Rationale

support recovery in client

### Example

```
	filePath := "downloadfile"
	err = s.Client.RecoverObjectBySecondary(s.ClientContext, bucketName, objectName, filePath, types.GetObjectOption{})
```

### Changes

Notable changes:
* support recovery object in client