### PR TITLE
feat: support off-chain-auth to sign the request

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -138,6 +138,9 @@ func New(chainID string, endpoint string, option Option) (Client, error) {
 
 	// register off-chain-auth pubkey to all sps
 	if option.OffChainAuthOption != nil {
+		if option.OffChainAuthOption.Seed == "" || option.OffChainAuthOption.Domain == "" {
+			return nil, errors.New("seed and domain can't be empty in OffChainAuthOption")
+		}
 		c.offChainAuthOption = option.OffChainAuthOption
 		if option.OffChainAuthOption.ShouldRegisterPubKey {
 			for spAddress, spEndpoint := range c.spEndpoints {

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -69,9 +69,10 @@ type client struct {
 	// The user agent info
 	userAgent string
 	// define if trace the error request to SP
-	isTraceEnabled bool
-	traceOutput    io.Writer
-	onlyTraceError bool
+	isTraceEnabled     bool
+	traceOutput        io.Writer
+	onlyTraceError     bool
+	offChainAuthOption *OffChainAuthOption
 }
 
 // Option is a configuration struct used to provide optional parameters to the client constructor.
@@ -86,6 +87,22 @@ type Option struct {
 	Transport http.RoundTripper
 	// Host is the target sp server hostname
 	Host string
+	// OffChainAuthOption consists of a EdDSA private key and the domain where the EdDSA keys will be registered for.
+	// This property should not be set in most cases unless you want to use go-sdk to test if the SP support off-chain-auth feature.
+	// Once this property is set, the request will be signed in "off-chain-auth" way rather than v1
+	OffChainAuthOption *OffChainAuthOption
+}
+
+// OffChainAuthOption consists of a EdDSA private key and the domain where the EdDSA keys will be registered for.
+// This auth mechanism is usually used in browser-based application.
+// That we support OffChainAuth configuration in go-sdk is to make the tests on off-chain-auth be convenient.
+type OffChainAuthOption struct {
+	// Seed is a EdDSA private key used for off-chain-auth.
+	Seed string
+	// Domain is the domain where the EdDSA keys will be registered for.
+	Domain string
+	// ShouldRegisterPubKey This should be set as true for the first time and could be set as false if the pubkey have been already been registered already.
+	ShouldRegisterPubKey bool
 }
 
 // New - instantiate greenfield chain with chain info, account info and options.
@@ -118,6 +135,21 @@ func New(chainID string, endpoint string, option Option) (Client, error) {
 	}
 
 	c.spEndpoints = spInfo
+
+	// register off-chain-auth pubkey to all sps
+	if option.OffChainAuthOption != nil {
+		c.offChainAuthOption = option.OffChainAuthOption
+		if option.OffChainAuthOption.ShouldRegisterPubKey {
+			for spAddress, spEndpoint := range c.spEndpoints {
+				registerResult, err := c.RegisterEDDSAPublicKey(spAddress, spEndpoint.Scheme+"://"+spEndpoint.Host)
+				if err != nil {
+					log.Error().Msg(fmt.Sprintf("Fail to RegisterEDDSAPublicKey for sp : %s", spEndpoint))
+				}
+				log.Info().Msg(fmt.Sprintf("registerResult: %s", registerResult))
+			}
+		}
+
+	}
 	return &c, nil
 }
 
@@ -496,6 +528,16 @@ func (c *client) generateURL(bucketName string, objectName string, relativePath 
 
 // signRequest signs the request and set authorization before send to server
 func (c *client) signRequest(req *http.Request) error {
+	// use offChainAuth if OffChainAuthOption is set
+	if c.offChainAuthOption != nil {
+		authStr := c.OffChainAuthSign()
+		// set auth header
+		req.Header.Set(types.HTTPHeaderAuthorization, authStr)
+		req.Header.Set("X-Gnfd-User-Address", c.defaultAccount.GetAddress().String())
+		req.Header.Set("X-Gnfd-App-Domain", c.offChainAuthOption.Domain)
+		return nil
+	}
+
 	unsignedMsg := httplib.GetMsgToSign(req)
 
 	// sign the request header info, generate the signature

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -1,0 +1,253 @@
+package client
+
+import (
+	"bytes"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
+	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
+	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards"
+	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards/eddsa"
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"golang.org/x/crypto/blake2b"
+	"io"
+	"io/ioutil"
+	"log"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type OffChainAuth interface {
+	RegisterEDDSAPublicKey(spEndpoint string, appDomain string, eddsaSeed string) (*storageTypes.MsgCreateObject, error)
+	OffChainAuthSign() string
+}
+
+func (c *client) OffChainAuthSign() string {
+	sk, _ := GenerateEddsaPrivateKey(c.offChainAuthOption.Seed)
+	unSignedMsg := fmt.Sprintf("InvokeSPAPI_%v", time.Now().Add(time.Minute*4).UnixMilli())
+	hFunc := mimc.NewMiMC()
+	sig, _ := sk.Sign([]byte(unSignedMsg), hFunc)
+	authString := fmt.Sprintf("OffChainAuth EDDSA,SignedMsg=%v,Signature=%v", unSignedMsg, hex.EncodeToString(sig))
+	return authString
+}
+
+// AuthNonce is the structure for off chain auth nonce response
+type AuthNonce struct {
+	CurrentNonce     int    `json:"current_nonce"`
+	CurrentPublicKey string `json:"current_public_key"`
+	ExpiryDate       int64  `json:"expiry_date"`
+	NextNonce        int    `json:"next_nonce"`
+}
+
+// getNonce
+func (c *client) GetNextNonce(spEndpoint string) (string, error) {
+	header := make(map[string]string)
+	header["X-Gnfd-User-Address"] = c.defaultAccount.GetAddress().String()
+	header["X-Gnfd-App-Domain"] = c.offChainAuthOption.Domain
+
+	response, err := HttpGetWithHeader(spEndpoint+"/auth/request_nonce", header)
+	if err != nil {
+		return "0", err
+	}
+	authNonce := AuthNonce{}
+	err = json.Unmarshal([]byte(response), &authNonce)
+	return strconv.Itoa(authNonce.NextNonce), nil
+}
+
+const (
+	UnsignedContentTemplate string = `%s wants you to sign in with your BNB Greenfield account:
+%s
+
+Register your identity public key %s
+
+URI: %s
+Version: 1
+Chain ID: 5600
+Issued At: %s
+Expiration Time: %s
+Resources:
+- SP %s (name: SP_001) with nonce: %s`
+)
+
+func (c *client) RegisterEDDSAPublicKey(spAddress string, spEndpoint string) (string, error) {
+	appDomain := c.offChainAuthOption.Domain
+	eddsaSeed := c.offChainAuthOption.Seed
+	nextNonce, err := c.GetNextNonce(spEndpoint)
+	if err != nil {
+		return "", err
+	}
+	// get the EDDSA private and public key
+	userEddsaPublicKeyStr := GetEddsaCompressedPublicKey(eddsaSeed)
+	log.Println("userEddsaPublicKeyStr is %s", userEddsaPublicKeyStr)
+
+	IssueDate := time.Now().Format(time.RFC3339)
+	// ExpiryDate := "2023-06-27T06:35:24Z"
+	ExpiryDate := time.Now().Add(time.Hour * 24).Format(time.RFC3339)
+	log.Println("ExpiryDate:", ExpiryDate)
+	unSignedContent := fmt.Sprintf(UnsignedContentTemplate, appDomain, c.defaultAccount.GetAddress().String(), userEddsaPublicKeyStr, appDomain, IssueDate, ExpiryDate, spAddress, nextNonce)
+
+	unSignedContentHash := accounts.TextHash([]byte(unSignedContent))
+	sig, _ := c.defaultAccount.GetKeyManager().Sign(unSignedContentHash)
+	authString := fmt.Sprintf("PersonalSign ECDSA-secp256k1,SignedMsg=%s,Signature=%s", unSignedContent, hexutil.Encode(sig))
+	authString = strings.ReplaceAll(authString, "\n", "\\n")
+	headers := make(map[string]string)
+	headers["x-gnfd-app-domain"] = appDomain
+	headers["x-gnfd-app-reg-nonce"] = nextNonce
+	headers["x-gnfd-app-reg-public-key"] = userEddsaPublicKeyStr
+	headers["x-gnfd-app-reg-expiry-date"] = ExpiryDate
+	headers["authorization"] = authString
+	headers["origin"] = appDomain
+	headers["x-gnfd-user-address"] = c.defaultAccount.GetAddress().String()
+	jsonResult, error1 := HttpPostWithHeader(spEndpoint+"/auth/update_key", "{}", headers)
+	log.Println("error1:", error1)
+	log.Println("jsonResult:", jsonResult)
+	return jsonResult, error1
+}
+
+func HttpGetWithHeader(url string, header map[string]string) (string, error) {
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Println("get error")
+	}
+	for key, value := range header {
+		req.Header.Set(key, value)
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println("get error")
+		return "", err
+	}
+	if (nil != resp) && (nil != resp.Body) {
+		defer resp.Body.Close()
+	}
+	body, err2 := ioutil.ReadAll(resp.Body)
+	if err2 != nil {
+		log.Println("ioutil read error")
+	}
+	return string(body), err
+}
+
+func HttpPostWithHeader(url string, jsonStr string, header map[string]string) (string, error) {
+	var json = []byte(jsonStr)
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(json))
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range header {
+		req.Header.Set(key, value)
+	}
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		log.Println("post error")
+		return "", err
+	}
+	if (nil != resp) && (nil != resp.Body) {
+		defer resp.Body.Close()
+	}
+	body, err2 := ioutil.ReadAll(resp.Body)
+	if err2 != nil {
+		log.Println("ioutil read error")
+	}
+	return string(body), err
+}
+
+func GetEddsaCompressedPublicKey(seed string) string {
+
+	sk, err := GenerateEddsaPrivateKey(seed)
+	if err != nil {
+		return err.Error()
+	}
+	var buf bytes.Buffer
+	buf.Write(sk.PublicKey.Bytes())
+	return hex.EncodeToString(buf.Bytes())
+}
+
+type (
+	PrivateKey = eddsa.PrivateKey
+)
+
+// GenerateEddsaPrivateKey: generate eddsa private key
+func GenerateEddsaPrivateKey(seed string) (sk *PrivateKey, err error) {
+	buf := make([]byte, 32)
+	copy(buf, seed)
+	reader := bytes.NewReader(buf)
+	sk, err = GenerateKey(reader)
+	return sk, err
+}
+
+const (
+	sizeFr = fr.Bytes
+)
+
+type PublicKey = eddsa.PublicKey
+
+func GenerateKey(r io.Reader) (*PrivateKey, error) {
+
+	c := twistededwards.GetEdwardsCurve()
+
+	var (
+		randSrc = make([]byte, 32)
+		scalar  = make([]byte, 32)
+		pub     PublicKey
+	)
+
+	// hash(h) = private_key || random_source, on 32 bytes each
+	seed := make([]byte, 32)
+	_, err := r.Read(seed)
+	if err != nil {
+		return nil, err
+	}
+	h := blake2b.Sum512(seed[:])
+	for i := 0; i < 32; i++ {
+		randSrc[i] = h[i+32]
+	}
+
+	// prune the key
+	// https://tools.ietf.org/html/rfc8032#section-5.1.5, key generation
+
+	h[0] &= 0xF8
+	h[31] &= 0x7F
+	h[31] |= 0x40
+
+	// 0xFC = 1111 1100
+	// convert 256 bits to 254 bits supporting bn254 curve
+
+	h[31] &= 0xFC
+
+	// reverse first bytes because setBytes interpret stream as big endian
+	// but in eddsa specs s is the first 32 bytes in little endian
+	for i, j := 0, sizeFr-1; i < sizeFr; i, j = i+1, j-1 {
+		scalar[i] = h[j]
+	}
+
+	a := new(big.Int).SetBytes(scalar[:])
+	for i := 253; i < 256; i++ {
+		a.SetBit(a, i, 0)
+	}
+
+	copy(scalar[:], a.FillBytes(make([]byte, 32)))
+
+	var bscalar big.Int
+	bscalar.SetBytes(scalar[:])
+	pub.A.ScalarMul(&c.Base, &bscalar)
+
+	var res [sizeFr * 3]byte
+	pubkBin := pub.A.Bytes()
+	subtle.ConstantTimeCopy(1, res[:sizeFr], pubkBin[:])
+	subtle.ConstantTimeCopy(1, res[sizeFr:2*sizeFr], scalar[:])
+	subtle.ConstantTimeCopy(1, res[2*sizeFr:], randSrc[:])
+
+	var sk = &PrivateKey{}
+	// make sure sk is not nil
+
+	_, err = sk.SetBytes(res[:])
+
+	return sk, err
+}

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"golang.org/x/crypto/blake2b"
 	"io"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"net/http"
@@ -58,6 +57,9 @@ func (c *client) GetNextNonce(spEndpoint string) (string, error) {
 	}
 	authNonce := AuthNonce{}
 	err = json.Unmarshal([]byte(response), &authNonce)
+	if err != nil {
+		return "0", err
+	}
 	return strconv.Itoa(authNonce.NextNonce), nil
 }
 
@@ -85,7 +87,7 @@ func (c *client) RegisterEDDSAPublicKey(spAddress string, spEndpoint string) (st
 	}
 	// get the EDDSA private and public key
 	userEddsaPublicKeyStr := GetEddsaCompressedPublicKey(eddsaSeed)
-	log.Println("userEddsaPublicKeyStr is %s", userEddsaPublicKeyStr)
+	log.Println("userEddsaPublicKeyStr is ", userEddsaPublicKeyStr)
 
 	IssueDate := time.Now().Format(time.RFC3339)
 	// ExpiryDate := "2023-06-27T06:35:24Z"
@@ -128,9 +130,9 @@ func HttpGetWithHeader(url string, header map[string]string) (string, error) {
 	if (nil != resp) && (nil != resp.Body) {
 		defer resp.Body.Close()
 	}
-	body, err2 := ioutil.ReadAll(resp.Body)
+	body, err2 := io.ReadAll(resp.Body)
 	if err2 != nil {
-		log.Println("ioutil read error")
+		log.Println("io read error")
 	}
 	return string(body), err
 }
@@ -138,6 +140,9 @@ func HttpGetWithHeader(url string, header map[string]string) (string, error) {
 func HttpPostWithHeader(url string, jsonStr string, header map[string]string) (string, error) {
 	var json = []byte(jsonStr)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(json))
+	if err != nil {
+		log.Println("post error")
+	}
 	req.Header.Set("Content-Type", "application/json")
 	for key, value := range header {
 		req.Header.Set(key, value)
@@ -151,9 +156,9 @@ func HttpPostWithHeader(url string, jsonStr string, header map[string]string) (s
 	if (nil != resp) && (nil != resp.Body) {
 		defer resp.Body.Close()
 	}
-	body, err2 := ioutil.ReadAll(resp.Body)
+	body, err2 := io.ReadAll(resp.Body)
 	if err2 != nil {
-		log.Println("ioutil read error")
+		log.Println("io read error")
 	}
 	return string(body), err
 }

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -153,9 +153,9 @@ func HttpPostWithHeader(url string, jsonStr string, header map[string]string) (s
 	if (nil != resp) && (nil != resp.Body) {
 		defer resp.Body.Close()
 	}
-	body, err2 := io.ReadAll(resp.Body)
-	if err2 != nil {
-		return "", err
+	body, readErr := io.ReadAll(resp.Body)
+	if readErr != nil {
+		return "", readErr
 	}
 	return string(body), err
 }

--- a/examples/common.go
+++ b/examples/common.go
@@ -9,7 +9,7 @@ import (
 const (
 	rpcAddr     = "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443"
 	chainId     = "greenfield_5600-1"
-	privateKey  = "4490e6024ace246eafa46b3b6d6bda1df443475f77c17b197c230cf7f244941b"
+	privateKey  = "xx"
 	objectSize  = 1000
 	groupMember = "0x.." // used for group examples
 	principal   = "0x.." // used for permission examples

--- a/examples/common.go
+++ b/examples/common.go
@@ -9,7 +9,7 @@ import (
 const (
 	rpcAddr     = "https://gnfd-testnet-fullnode-tendermint-us.bnbchain.org:443"
 	chainId     = "greenfield_5600-1"
-	privateKey  = "xx"
+	privateKey  = "4490e6024ace246eafa46b3b6d6bda1df443475f77c17b197c230cf7f244941b"
 	objectSize  = 1000
 	groupMember = "0x.." // used for group examples
 	principal   = "0x.." // used for permission examples

--- a/examples/offchainauth.go
+++ b/examples/offchainauth.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/bnb-chain/greenfield-go-sdk/client"
+	"github.com/bnb-chain/greenfield-go-sdk/types"
+)
+
+func main() {
+	account, err := types.NewAccountFromPrivateKey("test", privateKey)
+	if err != nil {
+		log.Fatalf("New account from private key error, %v", err)
+	}
+	cli, err := client.New(chainId, rpcAddr,
+		client.Option{
+			DefaultAccount: account,
+			OffChainAuthOption: &client.OffChainAuthOption{
+				Seed:                 "test_seed",
+				Domain:               "https://test.domain.com",
+				ShouldRegisterPubKey: true,
+			}})
+	if err != nil {
+		log.Fatalf("unable to new greenfield client, %v", err)
+	}
+	ctx := context.Background()
+	// list object
+	objects, err := cli.ListObjects(ctx, bucketName, types.ListObjectsOptions{true, "", "", "/", "", 10})
+	log.Println("list objects result:")
+	for _, obj := range objects.Objects {
+		i := obj.ObjectInfo
+		log.Printf("object: %s, status: %s\n", i.ObjectName, i.ObjectStatus)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -8,10 +8,14 @@ require (
 	github.com/bnb-chain/greenfield v0.2.3-alpha.1
 	github.com/bnb-chain/greenfield-common/go v0.0.0-20230512062756-5d7790d0ccbf
 	github.com/cometbft/cometbft v0.37.1
+	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.2
+	github.com/ethereum/go-ethereum v1.10.22
 	github.com/rs/zerolog v1.29.1
 	github.com/stretchr/testify v1.8.2
+	golang.org/x/crypto v0.8.0
 	google.golang.org/grpc v1.55.0
+
 )
 
 require (
@@ -48,7 +52,6 @@ require (
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/dvsekhvalnov/jose2go v1.5.0 // indirect
-	github.com/ethereum/go-ethereum v1.10.22 // indirect
 	github.com/ferranbt/fastssz v0.0.0-20210905181407-59cf6761a7d5 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/go-kit/kit v0.12.0 // indirect
@@ -124,7 +127,6 @@ require (
 	github.com/zondax/hid v0.9.1 // indirect
 	github.com/zondax/ledger-go v0.14.1 // indirect
 	go.etcd.io/bbolt v1.3.7 // indirect
-	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/exp v0.0.0-20230515195305-f3d0a9c9a5cc // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sys v0.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/cometbft/cometbft-db v0.7.0 h1:uBjbrBx4QzU0zOEnU8KxoDl18dMNgDh+zZRUE0
 github.com/cometbft/cometbft-db v0.7.0/go.mod h1:yiKJIm2WKrt6x8Cyxtq9YTEcIMPcEe4XPxhgX59Fzf0=
 github.com/consensys/bavard v0.1.8-0.20210406032232-f3452dc9b572/go.mod h1:Bpd0/3mZuaj6Sj+PqrmIquiOKy397AKGThQPaGzNXAQ=
 github.com/consensys/gnark-crypto v0.4.1-0.20210426202927-39ac3d4b3f1f/go.mod h1:815PAHg3wvysy0SyIqanF8gZ0Y1wjk/hrDHD/iT88+Q=
+github.com/consensys/gnark-crypto v0.7.0 h1:rwdy8+ssmLYRqKp+ryRRgQJl/rCq2uv+n83cOydm5UE=
+github.com/consensys/gnark-crypto v0.7.0/go.mod h1:KPSuJzyxkJA8xZ/+CV47tyqkr9MmpZA3PXivK4VPrVg=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -735,6 +737,7 @@ github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4FW1e6jwpg=
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
+github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.10.7 h1:p7ZhMD+KsSRozJr34udlUrhboJwWAgCg34+/ZZNvZZw=
@@ -940,6 +943,7 @@ github.com/mitchellh/mapstructure v1.4.1/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RR
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/mitchellh/pointerstructure v1.2.0/go.mod h1:BRAsLI5zgXmw97Lf6s25bs8ohIXc3tViBH44KcwB2g4=
+github.com/mmcloughlin/addchain v0.4.0 h1:SobOdjm2xLj1KkXN5/n0xTIWyZA2+s99UCY1iPfkHRY=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=


### PR DESCRIPTION
### support off-chain-auth to sign the request

SP supports both v1 and off-chain-auth as the authentication types.  In go-sdk, this pr will support the off-chain-auth.

### Rationale

Usually, go-sdk users don't have to use off-chain-auth, as they can use private key to sign the v1 authType agains the request. 
However, we are reported that some users might want to use go-sdk to test or detect if a giving SP meet our SP specification, which requires SP to implement off-chain-auth mechanism.  To test mechanism, the tester needs to :
1. create EdDSA private key and public key pairs
2. register the EdDSA public key to all SPs
3. sign request by using EdDSA private key.
These procedures are complex to use unless we simplify them in go-sdk


### Example

Check the examples in the pr:
greenfield-go-sdk/examples/offchainauth.go

### Changes

Notable changes:
* add offchainauth configuration. By default, users don't have to setup the offchainauth option.
* Registering offchainauth public keys when initializing the go-sdk client
* SIgn the request by using EdDSA private key if offchainauth option is configured.