### PR TITLE
fix: add resumeable upload test

### DIFF
--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -348,9 +348,8 @@ func (s *StorageTestSuite) waitSealObject(bucketName string, objectName string) 
 		time.Sleep(3 * time.Second)
 	}
 
-	endCheckTime := time.Now()
 	s.Require().Equal(objectDetail.ObjectInfo.GetObjectStatus().String(), "OBJECT_STATUS_SEALED")
-	s.T().Logf("---> Wait Seal Object cost %d s, <---", endCheckTime.Second()-startCheckTime.Second())
+	s.T().Logf("---> Wait Seal Object cost %d ms, <---", time.Since(startCheckTime).Milliseconds())
 }
 
 func (s *StorageTestSuite) createBigObjectWithoutPutObject() (bucket string, object string, objectbody bytes.Buffer) {


### PR DESCRIPTION
### Description

1. Increase the retry time for **`waitSealObject`** to wait for seal object.
2. Change the Big Object file size to 29MB.

### Rationale

NA

### Example

NA

### Changes

Notable changes:
* NA
* ...