### PR TITLE
fix: auth signedmsg

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -601,7 +601,6 @@ func (c *client) signRequest(req *http.Request) error {
 
 	authStr := []string{
 		types.AuthV1 + " " + types.SignAlgorithm,
-		" SignedMsg=" + hex.EncodeToString(unsignedMsg),
 		"Signature=" + hex.EncodeToString(signature),
 	}
 

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -47,6 +47,7 @@ type Client interface {
 	CrossChain
 	FeeGrant
 	VirtualGroup
+	OffChainAuth
 
 	GetDefaultAccount() (*types.Account, error)
 	SetDefaultAccount(account *types.Account)

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -28,12 +28,11 @@ type OffChainAuth interface {
 	OffChainAuthSign() string
 }
 
-func (c *client) OffChainAuthSign() string {
+func (c *client) OffChainAuthSign(unsignBytes []byte) string {
 	sk, _ := GenerateEddsaPrivateKey(c.offChainAuthOption.Seed)
-	unSignedMsg := fmt.Sprintf("InvokeSPAPI_%v", time.Now().Add(time.Minute*4).UnixMilli())
 	hFunc := mimc.NewMiMC()
-	sig, _ := sk.Sign([]byte(unSignedMsg), hFunc)
-	authString := fmt.Sprintf("OffChainAuth EDDSA,SignedMsg=%v,Signature=%v", unSignedMsg, hex.EncodeToString(sig))
+	sig, _ := sk.Sign(unsignBytes, hFunc)
+	authString := fmt.Sprintf("OffChainAuth EDDSA,SignedMsg=%v,Signature=%v", hex.EncodeToString(unsignBytes), hex.EncodeToString(sig))
 	return authString
 }
 
@@ -103,7 +102,7 @@ func (c *client) RegisterEDDSAPublicKey(spAddress string, spEndpoint string) (st
 	headers["x-gnfd-app-domain"] = appDomain
 	headers["x-gnfd-app-reg-nonce"] = nextNonce
 	headers["x-gnfd-app-reg-public-key"] = userEddsaPublicKeyStr
-	headers["x-gnfd-app-reg-expiry-date"] = ExpiryDate
+	headers["X-Gnfd-Expiry-Timestamp"] = ExpiryDate
 	headers["authorization"] = authString
 	headers["origin"] = appDomain
 	headers["x-gnfd-user-address"] = c.defaultAccount.GetAddress().String()

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -31,7 +31,7 @@ func (c *client) OffChainAuthSign(unsignBytes []byte) string {
 	sk, _ := GenerateEddsaPrivateKey(c.offChainAuthOption.Seed)
 	hFunc := mimc.NewMiMC()
 	sig, _ := sk.Sign(unsignBytes, hFunc)
-	authString := fmt.Sprintf("OffChainAuth EDDSA,SignedMsg=%v,Signature=%v", hex.EncodeToString(unsignBytes), hex.EncodeToString(sig))
+	authString := fmt.Sprintf("OffChainAuth EDDSA,Signature=%v", hex.EncodeToString(sig))
 	return authString
 }
 

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards"
@@ -24,8 +23,8 @@ import (
 )
 
 type OffChainAuth interface {
-	RegisterEDDSAPublicKey(spEndpoint string, appDomain string, eddsaSeed string) (*storageTypes.MsgCreateObject, error)
-	OffChainAuthSign() string
+	RegisterEDDSAPublicKey(spAddress string, spEndpoint string) (string, error)
+	OffChainAuthSign(unsignBytes []byte) string
 }
 
 func (c *client) OffChainAuthSign(unsignBytes []byte) string {

--- a/examples/offchainauth.go
+++ b/examples/offchainauth.go
@@ -26,7 +26,11 @@ func main() {
 	}
 	ctx := context.Background()
 	// list object
-	objects, err := cli.ListObjects(ctx, bucketName, types.ListObjectsOptions{ShowRemovedObject: true, Delimiter: "/", MaxKeys: 10})
+	objects, err := cli.ListObjects(ctx, bucketName, types.ListObjectsOptions{
+		true, "", "", "/", "", 10, &types.EndPointOptions{
+			Endpoint:  "",
+			SPAddress: "",
+		}})
 	log.Println("list objects result:")
 	for _, obj := range objects.Objects {
 		i := obj.ObjectInfo

--- a/examples/storage_by_offchainauth.go
+++ b/examples/storage_by_offchainauth.go
@@ -19,7 +19,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("New account from private key error, %v", err)
 	}
-	cli, err := client.New(chainId, rpcAddr, client.Option{DefaultAccount: account})
+	//cli, err := client.New(chainId, rpcAddr, client.Option{DefaultAccount: account})
+	cli, err := client.New(chainId, rpcAddr, client.Option{
+		DefaultAccount: account,
+		OffChainAuthOption: &client.OffChainAuthOption{
+			Seed:                 "test_seed",
+			Domain:               "https://test.domain.com",
+			ShouldRegisterPubKey: true,
+		},
+	})
 	if err != nil {
 		log.Fatalf("unable to new greenfield client, %v", err)
 	}
@@ -31,8 +39,8 @@ func main() {
 		log.Fatalf("fail to list in service sps")
 	}
 	// choose the first sp to be the primary SP
-	primarySP := spLists[0].GetOperatorAddress()
-
+	primarySP := spLists[6].GetOperatorAddress()
+	log.Println(primarySP)
 	// create bucket
 	_, err = cli.CreateBucket(ctx, bucketName, primarySP, types.CreateBucketOptions{})
 	handleErr(err, "CreateBucket")
@@ -61,7 +69,6 @@ func main() {
 	log.Printf("object: %s has been uploaded to SP\n", objectName)
 
 	waitObjectSeal(cli, bucketName, objectName)
-	// wait for block_syncer to sync up data from chain
 	time.Sleep(time.Second * 5)
 	// get object
 	reader, info, err := cli.GetObject(ctx, bucketName, objectName, types.GetObjectOptions{})

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/bnb-chain/greenfield v0.2.3-alpha.6
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230724122553-ecdf648b1937
 	github.com/cometbft/cometbft v0.37.1
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2 h1:ys9kmgtRx04wcCextE6Cr
 github.com/bnb-chain/greenfield-cometbft v0.0.2-alpha.2/go.mod h1:EBmwmUdaNbGPyGjf1cMuoN3pAeM2tQu7Lfg95813EAw=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d h1:G14aW9eW+l7ou10kRPlBiXOZqG+qPk3YYjEXgJid6jk=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230724122553-ecdf648b1937 h1:k2cVpCvECGZ0uqExZR82VrHcPDkDdwHrx1c9Pk00xEE=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230724122553-ecdf648b1937/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.4 h1:Q5EzT1r3jKv0BZgVJkYFVvqn+7Ghj6RU7mUM0VkUZ4U=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3-alpha.4/go.mod h1:EghjYxFg4NRNMfTJ6g9rVhjImhXQm+tuboknHqeGmJA=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=

--- a/types/const.go
+++ b/types/const.go
@@ -70,4 +70,5 @@ const (
 	FilePermMode   = os.FileMode(0664) // Default file permission
 
 	WaitTxContextTimeOut = 1 * time.Second
+	DefaultExpireSeconds = 1000
 )


### PR DESCRIPTION
### Description

Refactoring auth code after security review

### Changes

Notable changes: 
1. Make the offchainauth's signedMsg be consistent with the V1's signedMsg, which are constructed by commonhttp.GetMsgToSign
5. Add "X-Gnfd-Expiry-Timestamp" header for both off-chain-auth and V1 auth, in order to make the replay attack impossible after sig is expired.


