### PR TITLE
feat: auth refactoring

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   GreenfieldTag: v0.2.3
-  GreenfieldStorageProviderTag: 1c9a5c694b7fbc5ab3b8f0f941dfd9f24c5a6de3
+  GreenfieldStorageProviderTag: 441a54828a112f1178130baf7c2a6d79de756439
   GOPRIVATE: github.com/bnb-chain
   GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
   MYSQL_USER: root

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   GreenfieldTag: v0.2.3
-  GreenfieldStorageProviderTag: 30ca7aff82951156db76b475327d6d3c5bf93e48
+  GreenfieldStorageProviderTag: 1c9a5c694b7fbc5ab3b8f0f941dfd9f24c5a6de3
   GOPRIVATE: github.com/bnb-chain
   GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
   MYSQL_USER: root

--- a/client/api_basic.go
+++ b/client/api_basic.go
@@ -2,10 +2,11 @@ package client
 
 import (
 	"context"
-	"github.com/cometbft/cometbft/votepool"
-	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"strings"
 	"time"
+
+	"github.com/cometbft/cometbft/votepool"
+	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 
 	"cosmossdk.io/errors"
 	gosdktypes "github.com/bnb-chain/greenfield-go-sdk/types"

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -225,7 +225,6 @@ func (c *client) pickStorageProviderByBucket(bucketName string) (*types.StorageP
 		return sp, nil
 	}
 	return nil, fmt.Errorf("the storage provider %d not exists on chain", familyResp.GlobalVirtualGroupFamily.PrimarySpId)
-
 }
 
 // getSPUrlByID route url of the sp from sp id

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -603,7 +603,7 @@ func (c *client) signRequest(req *http.Request) error {
 	}
 
 	authStr := []string{
-		types.GNFD1_ECDSA,
+		httplib.Gnfd1Ecdsa,
 		"Signature=" + hex.EncodeToString(signature),
 	}
 

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -47,6 +47,7 @@ type Client interface {
 	CrossChain
 	FeeGrant
 	VirtualGroup
+	OffChainAuth
 
 	GetDefaultAccount() (*types.Account, error)
 	SetDefaultAccount(account *types.Account)
@@ -76,6 +77,7 @@ type client struct {
 	onlyTraceError     bool
 	offChainAuthOption *OffChainAuthOption
 	useWebsocketConn   bool
+	expireSeconds      uint64
 }
 
 // Option is a configuration struct used to provide optional parameters to the client constructor.
@@ -96,6 +98,8 @@ type Option struct {
 	OffChainAuthOption *OffChainAuthOption
 	// UseWebSocketConn specifies that connection to Chain is via websocket
 	UseWebSocketConn bool
+	// ExpireSeconds indicates the number of seconds after which the authentication of the request sent to the SP will become invalid，the default value is 1000
+	ExpireSeconds uint64
 }
 
 // OffChainAuthOption consists of a EdDSA private key and the domain where the EdDSA keys will be registered for.
@@ -132,6 +136,10 @@ func New(chainID string, endpoint string, option Option) (Client, error) {
 		cc.SetKeyManager(option.DefaultAccount.GetKeyManager())
 	}
 
+	if option.ExpireSeconds > httplib.MaxExpiryAgeInSec {
+		return nil, errors.New("the configured expire time exceeds max expire time")
+	}
+
 	c := client{
 		chainClient:      cc,
 		httpClient:       &http.Client{Transport: option.Transport},
@@ -141,6 +149,7 @@ func New(chainID string, endpoint string, option Option) (Client, error) {
 		host:             option.Host,
 		storageProviders: make(map[uint32]*types.StorageProvider),
 		useWebsocketConn: option.UseWebSocketConn,
+		expireSeconds:    option.ExpireSeconds,
 	}
 
 	// fetch sp endpoints info from chain
@@ -417,6 +426,14 @@ func (c *client) newRequest(ctx context.Context, method string, meta requestMeta
 	stNow := time.Now().UTC()
 	req.Header.Set(types.HTTPHeaderDate, stNow.Format(types.Iso8601DateFormatSecond))
 
+	// set expiry for authorization
+	// if the user has set the expiry seconds num, use the user option value, if not , use the default expiry value
+	if c.expireSeconds == 0 {
+		req.Header.Set(httplib.HTTPHeaderExpiryTimestamp, stNow.Add(time.Second*types.DefaultExpireSeconds).Format(types.Iso8601DateFormatSecond))
+	} else {
+		req.Header.Set(httplib.HTTPHeaderExpiryTimestamp, stNow.Add(time.Second*time.Duration(c.expireSeconds)).Format(types.Iso8601DateFormatSecond))
+	}
+
 	// set user-agent
 	req.Header.Set(types.HTTPHeaderUserAgent, c.userAgent)
 
@@ -568,15 +585,16 @@ func (c *client) generateURL(bucketName string, objectName string, relativePath 
 func (c *client) signRequest(req *http.Request) error {
 	// use offChainAuth if OffChainAuthOption is set
 	if c.offChainAuthOption != nil {
-		authStr := c.OffChainAuthSign()
-		// set auth header
-		req.Header.Set(types.HTTPHeaderAuthorization, authStr)
 		req.Header.Set("X-Gnfd-User-Address", c.defaultAccount.GetAddress().String())
 		req.Header.Set("X-Gnfd-App-Domain", c.offChainAuthOption.Domain)
+		unsignedMsg := httplib.GetMsgToSignInGNFD1Auth(req)
+		authStr := c.OffChainAuthSign(unsignedMsg)
+		// set auth header
+		req.Header.Set(types.HTTPHeaderAuthorization, authStr)
 		return nil
 	}
 
-	unsignedMsg := httplib.GetMsgToSign(req)
+	unsignedMsg := httplib.GetMsgToSignInGNFD1Auth(req)
 
 	// sign the request header info, generate the signature
 	signature, err := c.MustGetDefaultAccount().Sign(unsignedMsg)
@@ -585,8 +603,7 @@ func (c *client) signRequest(req *http.Request) error {
 	}
 
 	authStr := []string{
-		types.AuthV1 + " " + types.SignAlgorithm,
-		" SignedMsg=" + hex.EncodeToString(unsignedMsg),
+		types.GNFD1_ECDSA,
 		"Signature=" + hex.EncodeToString(signature),
 	}
 

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -660,7 +660,7 @@ func (c *client) FGetObjectResumable(ctx context.Context, bucketName, objectName
 
 		// truncated file to part size integer multiples
 		if fileSizeWithoutFirstSeg%partSize != 0 {
-			file, err = os.OpenFile(tempFilePath, os.O_RDWR, 0644)
+			file, err = os.OpenFile(tempFilePath, os.O_RDWR, 0o644)
 			if err != nil {
 				return err
 			}
@@ -1093,7 +1093,6 @@ func (c *client) getObjectOffsetFromSP(ctx context.Context, bucketName, objectNa
 	}
 
 	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, endpoint)
-
 	if err != nil {
 		// not exist
 		if find := strings.Contains(err.Error(), "no uploading record"); find {

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/bnb-chain/greenfield-go-sdk/types"
+	httplib "github.com/bnb-chain/greenfield-common/go/http"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
 	"github.com/consensys/gnark-crypto/ecc/bn254/twistededwards"
@@ -32,7 +32,7 @@ func (c *client) OffChainAuthSign(unsignBytes []byte) string {
 	sk, _ := GenerateEddsaPrivateKey(c.offChainAuthOption.Seed)
 	hFunc := mimc.NewMiMC()
 	sig, _ := sk.Sign(unsignBytes, hFunc)
-	authString := fmt.Sprintf("%s,Signature=%v", types.GNFD1_EDDSA, hex.EncodeToString(sig))
+	authString := fmt.Sprintf("%s,Signature=%v", httplib.Gnfd1Eddsa, hex.EncodeToString(sig))
 	return authString
 }
 

--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -6,6 +6,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math/big"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
 	httplib "github.com/bnb-chain/greenfield-common/go/http"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr/mimc"
@@ -15,12 +22,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/blake2b"
-	"io"
-	"math/big"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 )
 
 type OffChainAuth interface {
@@ -135,7 +136,7 @@ func HttpGetWithHeader(url string, header map[string]string) (string, error) {
 }
 
 func HttpPostWithHeader(url string, jsonStr string, header map[string]string) (string, error) {
-	var json = []byte(jsonStr)
+	json := []byte(jsonStr)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer(json))
 	if err != nil {
 		return "", err
@@ -160,7 +161,6 @@ func HttpPostWithHeader(url string, jsonStr string, header map[string]string) (s
 }
 
 func GetEddsaCompressedPublicKey(seed string) string {
-
 	sk, err := GenerateEddsaPrivateKey(seed)
 	if err != nil {
 		return err.Error()
@@ -190,7 +190,6 @@ const (
 type PublicKey = eddsa.PublicKey
 
 func GenerateKey(r io.Reader) (*PrivateKey, error) {
-
 	c := twistededwards.GetEdwardsCurve()
 
 	var (
@@ -245,7 +244,7 @@ func GenerateKey(r io.Reader) (*PrivateKey, error) {
 	subtle.ConstantTimeCopy(1, res[sizeFr:2*sizeFr], scalar[:])
 	subtle.ConstantTimeCopy(1, res[2*sizeFr:], randSrc[:])
 
-	var sk = &PrivateKey{}
+	sk := &PrivateKey{}
 	// make sure sk is not nil
 
 	_, err = sk.SetBytes(res[:])

--- a/e2e/e2e_migrate_bucket_test.go
+++ b/e2e/e2e_migrate_bucket_test.go
@@ -250,5 +250,4 @@ func (s *BucketMigrateTestSuite) Test_Bucket_Migrate_Simple_Conflict_Case() {
 		s.Require().NoError(err)
 		s.Require().Equal(objectBytes, buffer.Bytes())
 	}
-
 }

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -408,7 +408,6 @@ func getTmpFilesInDirectory(directory string) ([]string, error) {
 
 		return nil
 	})
-
 	if err != nil {
 		return nil, err
 	}
@@ -430,7 +429,7 @@ func (s *StorageTestSuite) TruncateDownloadTempFileToLessPartsize() {
 	s.Require().NoError(err)
 	tempFilePath := files[0]
 
-	file, err := os.OpenFile(tempFilePath, os.O_RDWR, 0666)
+	file, err := os.OpenFile(tempFilePath, os.O_RDWR, 0o666)
 	s.Require().NoError(err)
 	defer file.Close()
 
@@ -495,7 +494,7 @@ func (s *StorageTestSuite) Test_Resumable_Upload_And_Download() {
 
 	err = s.Client.FGetObjectResumable(s.ClientContext, bucketName, objectName, resumableDownloadFile, types.GetObjectOptions{PartSize: 16 * 1024 * 1024})
 	s.Require().NoError(err)
-	//download success, checkpoint file has been deleted
+	// download success, checkpoint file has been deleted
 
 	isSame, err = types.CompareFiles(resumableDownloadFile, fGetObjectFileName)
 	s.Require().True(isSame)
@@ -516,7 +515,7 @@ func (s *StorageTestSuite) Test_Resumable_Upload_And_Download() {
 
 	err = s.Client.FGetObjectResumable(s.ClientContext, bucketName, objectName, resumableDownloadLessPartFile, types.GetObjectOptions{PartSize: 16 * 1024 * 1024})
 	s.Require().NoError(err)
-	//download success, checkpoint file has been deleted
+	// download success, checkpoint file has been deleted
 
 	isSame, err = types.CompareFiles(resumableDownloadLessPartFile, fGetObjectFileName)
 	s.Require().True(isSame)

--- a/examples/common.go
+++ b/examples/common.go
@@ -54,3 +54,26 @@ func waitObjectSeal(cli client.Client, bucketName, objectName string) {
 		}
 	}
 }
+
+func waitObjectSeal(cli client.Client, bucketName, objectName string) {
+	ctx := context.Background()
+	// wait for the object to be sealed
+	timeout := time.After(15 * time.Second)
+	ticker := time.NewTicker(2 * time.Second)
+
+	for {
+		select {
+		case <-timeout:
+			err := errors.New("object not sealed after 15 seconds")
+			handleErr(err, "HeadObject")
+		case <-ticker.C:
+			objectDetail, err := cli.HeadObject(ctx, bucketName, objectName)
+			handleErr(err, "HeadObject")
+			if objectDetail.ObjectInfo.GetObjectStatus().String() == "OBJECT_STATUS_SEALED" {
+				ticker.Stop()
+				fmt.Printf("put object %s successfully \n", objectName)
+				return
+			}
+		}
+	}
+}

--- a/examples/common.go
+++ b/examples/common.go
@@ -54,26 +54,3 @@ func waitObjectSeal(cli client.Client, bucketName, objectName string) {
 		}
 	}
 }
-
-func waitObjectSeal(cli client.Client, bucketName, objectName string) {
-	ctx := context.Background()
-	// wait for the object to be sealed
-	timeout := time.After(15 * time.Second)
-	ticker := time.NewTicker(2 * time.Second)
-
-	for {
-		select {
-		case <-timeout:
-			err := errors.New("object not sealed after 15 seconds")
-			handleErr(err, "HeadObject")
-		case <-ticker.C:
-			objectDetail, err := cli.HeadObject(ctx, bucketName, objectName)
-			handleErr(err, "HeadObject")
-			if objectDetail.ObjectInfo.GetObjectStatus().String() == "OBJECT_STATUS_SEALED" {
-				ticker.Stop()
-				fmt.Printf("put object %s successfully \n", objectName)
-				return
-			}
-		}
-	}
-}

--- a/examples/offchainauth.go
+++ b/examples/offchainauth.go
@@ -26,7 +26,11 @@ func main() {
 	}
 	ctx := context.Background()
 	// list object
-	objects, err := cli.ListObjects(ctx, bucketName, types.ListObjectsOptions{ShowRemovedObject: true, Delimiter: "/", MaxKeys: 10})
+	objects, err := cli.ListObjects(ctx, bucketName, types.ListObjectsOptions{
+		true, "", "", "/", "", 10, &types.EndPointOptions{
+			Endpoint:  "",
+			SPAddress: "",
+		}})
 	log.Println("list objects result:")
 	for _, obj := range objects.Objects {
 		i := obj.ObjectInfo

--- a/examples/offchainauth.go
+++ b/examples/offchainauth.go
@@ -20,7 +20,8 @@ func main() {
 				Seed:                 "test_seed",
 				Domain:               "https://test.domain.com",
 				ShouldRegisterPubKey: true,
-			}})
+			},
+		})
 	if err != nil {
 		log.Fatalf("unable to new greenfield client, %v", err)
 	}
@@ -30,7 +31,8 @@ func main() {
 		true, "", "", "/", "", 10, &types.EndPointOptions{
 			Endpoint:  "",
 			SPAddress: "",
-		}})
+		},
+	})
 	log.Println("list objects result:")
 	for _, obj := range objects.Objects {
 		i := obj.ObjectInfo

--- a/examples/storage.go
+++ b/examples/storage.go
@@ -78,7 +78,8 @@ func main() {
 		ShowRemovedObject: false, Delimiter: "", MaxKeys: 100, EndPointOptions: &types.EndPointOptions{
 			Endpoint:  httpsAddr,
 			SPAddress: "",
-		}})
+		},
+	})
 	log.Println("list objects result:")
 	for _, obj := range objects.Objects {
 		i := obj.ObjectInfo
@@ -90,7 +91,8 @@ func main() {
 		ShowRemovedBucket: false, EndPointOptions: &types.EndPointOptions{
 			Endpoint:  httpsAddr,
 			SPAddress: "",
-		}})
+		},
+	})
 	log.Println("list buckets result:")
 	for _, bucket := range bucketsList.Buckets {
 		i := bucket.BucketInfo

--- a/examples/storage_by_offchainauth.go
+++ b/examples/storage_by_offchainauth.go
@@ -19,7 +19,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("New account from private key error, %v", err)
 	}
-	//cli, err := client.New(chainId, rpcAddr, client.Option{DefaultAccount: account})
+	// cli, err := client.New(chainId, rpcAddr, client.Option{DefaultAccount: account})
 	cli, err := client.New(chainId, rpcAddr, client.Option{
 		DefaultAccount: account,
 		OffChainAuthOption: &client.OffChainAuthOption{
@@ -85,7 +85,8 @@ func main() {
 		true, "", "", "/", "", 10, &types.EndPointOptions{
 			Endpoint:  httpsAddr,
 			SPAddress: "",
-		}})
+		},
+	})
 	log.Println("list objects result:")
 	for _, obj := range objects.Objects {
 		i := obj.ObjectInfo

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/bnb-chain/greenfield v0.2.3
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9 // indirect
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9
 	github.com/cometbft/cometbft v0.37.1
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3
@@ -29,7 +29,6 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 // indirect
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f // indirect
 	github.com/btcsuite/btcd v0.23.3 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/bnb-chain/greenfield v0.2.3
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9 // indirect
 	github.com/cometbft/cometbft v0.37.1
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/bnb-chain/greenfield v0.2.3
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d
 	github.com/cometbft/cometbft v0.37.1
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3
@@ -29,6 +28,7 @@ require (
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 // indirect
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f // indirect
 	github.com/btcsuite/btcd v0.23.3 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
 	github.com/btcsuite/btcd/btcutil v1.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,10 +158,8 @@ github.com/bnb-chain/greenfield-cometbft v0.0.2 h1:bRamS8Lq1lA3ttRLZBha22uiNG5tq
 github.com/bnb-chain/greenfield-cometbft v0.0.2/go.mod h1:EBmwmUdaNbGPyGjf1cMuoN3pAeM2tQu7Lfg95813EAw=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d h1:G14aW9eW+l7ou10kRPlBiXOZqG+qPk3YYjEXgJid6jk=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f h1:CWEvDMYmvBp3KoGCJfzbrDF+KmSpr0Bp89/C89Oje94=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9 h1:WcnWlEIgua/k3Ho78JVPKQXR/bFrpgs8k+f9m/YwYLU=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3 h1:bpro+qS2jjSi7vQN781gtxebuYNDrLewAye+iGB299c=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3/go.mod h1:hpvg93+VGXHAcv/pVVdp24Ik/9miw4uRh8+tD0DDYas=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,8 @@ github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d h1:G14aW9eW+l7ou10kRPlBiXOZqG+qPk3YYjEXgJid6jk=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230720022901-7e7158fd397d/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f h1:CWEvDMYmvBp3KoGCJfzbrDF+KmSpr0Bp89/C89Oje94=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230807023829-a6f5d8d75f1f/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3 h1:bpro+qS2jjSi7vQN781gtxebuYNDrLewAye+iGB299c=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3/go.mod h1:hpvg93+VGXHAcv/pVVdp24Ik/9miw4uRh8+tD0DDYas=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=

--- a/types/const.go
+++ b/types/const.go
@@ -13,9 +13,6 @@ const (
 
 	HTTPHeaderAuthorization = "Authorization"
 
-	GNFD1_ECDSA = "GNFD1-ECDSA" // The original name is authTypeV1
-	GNFD1_EDDSA = "GNFD1-EDDSA" // this is used for off-chain auth, usually in web application
-
 	HTTPHeaderContentLength   = "Content-Length"
 	HTTPHeaderContentMD5      = "Content-MD5"
 	HTTPHeaderContentType     = "Content-Type"

--- a/types/const.go
+++ b/types/const.go
@@ -12,8 +12,9 @@ const (
 	UserAgent = "Greenfield (" + runtime.GOOS + "; " + runtime.GOARCH + ") " + libName + "/" + Version
 
 	HTTPHeaderAuthorization = "Authorization"
-	SignAlgorithm           = "ECDSA-secp256k1"
-	AuthV1                  = "authTypeV1"
+
+	GNFD1_ECDSA = "GNFD1-ECDSA" // The original name is authTypeV1
+	GNFD1_EDDSA = "GNFD1-EDDSA" // this is used for off-chain auth, usually in web application
 
 	HTTPHeaderContentLength   = "Content-Length"
 	HTTPHeaderContentMD5      = "Content-MD5"
@@ -70,4 +71,5 @@ const (
 	FilePermMode   = os.FileMode(0664) // Default file permission
 
 	WaitTxContextTimeOut = 1 * time.Second
+	DefaultExpireSeconds = 1000
 )

--- a/types/const.go
+++ b/types/const.go
@@ -64,8 +64,8 @@ const (
 	// putObject behaves internally as multipart.
 	MinPartSize = 1024 * 1024 * 32
 
-	TempFileSuffix = ".temp"           // Temp file suffix
-	FilePermMode   = os.FileMode(0664) // Default file permission
+	TempFileSuffix = ".temp"            // Temp file suffix
+	FilePermMode   = os.FileMode(0o664) // Default file permission
 
 	WaitTxContextTimeOut = 1 * time.Second
 	DefaultExpireSeconds = 1000

--- a/types/types.go
+++ b/types/types.go
@@ -12,9 +12,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-var (
-	letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
-)
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // Principal indicates the marshaled Principal content of greenfield permission types,
 // user can generate it by NewPrincipalWithAccount or NewPrincipalWithGroupId method in utils


### PR DESCRIPTION
### Description

Refactoring auth code after security review

### Changes

Notable changes: 
1. Make the offchainauth's signedMsg be consistent with the V1's signedMsg, which are constructed by commonhttp.GetMsgToSign
5. Add "X-Gnfd-Expiry-Timestamp" header for both off-chain-auth and V1 auth, in order to make the replay attack impossible after sig is expired.


