### PR TITLE
feat: rename personal sign auth name

### DIFF
--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -97,7 +97,7 @@ func (c *client) RegisterEDDSAPublicKey(spAddress string, spEndpoint string) (st
 
 	unSignedContentHash := accounts.TextHash([]byte(unSignedContent))
 	sig, _ := c.defaultAccount.GetKeyManager().Sign(unSignedContentHash)
-	authString := fmt.Sprintf("PersonalSign ECDSA-secp256k1,SignedMsg=%s,Signature=%s", unSignedContent, hexutil.Encode(sig))
+	authString := fmt.Sprintf("%s,SignedMsg=%s,Signature=%s", httplib.Gnfd1EthPersonalSign, unSignedContent, hexutil.Encode(sig))
 	authString = strings.ReplaceAll(authString, "\n", "\\n")
 	headers := make(map[string]string)
 	headers["x-gnfd-app-domain"] = appDomain

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/bnb-chain/greenfield v0.2.3
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230809025353-fd0519705054
 	github.com/cometbft/cometbft v0.37.1
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3

--- a/go.sum
+++ b/go.sum
@@ -160,6 +160,10 @@ github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9 h1:WcnWlEIgua/k3Ho78JVPKQXR/bFrpgs8k+f9m/YwYLU=
 github.com/bnb-chain/greenfield-common/go v0.0.0-20230807072950-7d065b289ab9/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230809022935-c516b4fc764d h1:4iRAREwEN//H8roim2Dc/mPnDdmIooGxIgq+a5VIODI=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230809022935-c516b4fc764d/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230809025353-fd0519705054 h1:74pdUdHjo9QNgjSifIgzbDcloqFJ2I+qo715tOXy/oM=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230809025353-fd0519705054/go.mod h1:GEjCahULmz99qx5k8WGWa7cTXIUjoNMNW+J92I+kTWg=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3 h1:bpro+qS2jjSi7vQN781gtxebuYNDrLewAye+iGB299c=
 github.com/bnb-chain/greenfield-cosmos-sdk v0.2.3/go.mod h1:hpvg93+VGXHAcv/pVVdp24Ik/9miw4uRh8+tD0DDYas=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230425074444-eb5869b05fe9 h1:6fLpmmI0EZvDTfPvI0zy5dBaaTUboHnEkoC5/p/w8TQ=


### PR DESCRIPTION
### Description
feat: rename personal sign

It was "PersonalSign ECDSA-secp256k1" and it is now renamed to "GNFD1-ETH-PERSONAL_SIGN"