### PR TITLE
feat: support challenge admin v2 API

### DIFF
--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -79,8 +79,11 @@ func (c *Client) GetCreateBucketApproval(ctx context.Context, createBucketMsg *s
 	}
 
 	sendOpt := sendOptions{
-		method:     http.MethodGet,
-		isAdminApi: true,
+		method: http.MethodGet,
+		adminInfo: AdminAPIInfo{
+			isAdminApi:   true,
+			adminVersion: types.AdminV1Version,
+		},
 	}
 
 	primarySPAddr := createBucketMsg.GetPrimarySpAddress()
@@ -872,8 +875,11 @@ func (c *Client) GetMigrateBucketApproval(ctx context.Context, migrateBucketMsg 
 	}
 
 	sendOpt := sendOptions{
-		method:     http.MethodGet,
-		isAdminApi: true,
+		method: http.MethodGet,
+		adminInfo: AdminAPIInfo{
+			isAdminApi:   true,
+			adminVersion: types.AdminV1Version,
+		},
 	}
 
 	primarySPID := migrateBucketMsg.DstPrimarySpId

--- a/client/api_bucket.go
+++ b/client/api_bucket.go
@@ -81,7 +81,7 @@ func (c *Client) GetCreateBucketApproval(ctx context.Context, createBucketMsg *s
 	sendOpt := sendOptions{
 		method: http.MethodGet,
 		adminInfo: AdminAPIInfo{
-			isAdminApi:   true,
+			isAdminAPI:   true,
 			adminVersion: types.AdminV1Version,
 		},
 	}
@@ -877,7 +877,7 @@ func (c *Client) GetMigrateBucketApproval(ctx context.Context, migrateBucketMsg 
 	sendOpt := sendOptions{
 		method: http.MethodGet,
 		adminInfo: AdminAPIInfo{
-			isAdminApi:   true,
+			isAdminAPI:   true,
 			adminVersion: types.AdminV1Version,
 		},
 	}

--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -1,9 +1,13 @@
 package client
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
+	"encoding/xml"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -79,8 +83,19 @@ func (c *Client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 
 	sendOpt := sendOptions{
 		method:           http.MethodGet,
-		isAdminApi:       true,
 		disableCloseBody: true,
+	}
+
+	if opts.UseV2version {
+		sendOpt.adminInfo = AdminAPIInfo{
+			isAdminApi:   true,
+			adminVersion: types.AdminV2Version,
+		}
+	} else {
+		sendOpt.adminInfo = AdminAPIInfo{
+			isAdminApi:   true,
+			adminVersion: types.AdminV1Version,
+		}
 	}
 
 	var endpoint *url.URL
@@ -134,27 +149,62 @@ func (c *Client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 		return types.ChallengeResult{}, err
 	}
 
-	// fetch integrity hash
-	integrityHash := resp.Header.Get(types.HTTPHeaderIntegrityHash)
-	// fetch piece hashes
-	pieceHashes := resp.Header.Get(types.HTTPHeaderPieceHash)
+	var result types.ChallengeResult
 
-	if integrityHash == "" || pieceHashes == "" {
-		utils.CloseResponse(resp)
-		return types.ChallengeResult{}, errors.New("fail to fetch hash info")
+	// if it is the v2 challenge API, fetch the info from the xml body
+	if opts.UseV2version {
+		challengeV2Info := types.ChallengeV2Result{}
+		// decode the xml content from response body
+		err = xml.NewDecoder(resp.Body).Decode(&challengeV2Info)
+		if err != nil {
+			utils.CloseResponse(resp)
+			return types.ChallengeResult{}, err
+		}
+
+		if challengeV2Info.IntegrityHash == "" || challengeV2Info.PieceHash == "" || challengeV2Info.PieceData == "" {
+			utils.CloseResponse(resp)
+			return types.ChallengeResult{}, errors.New("fail to fetch hash info")
+		}
+
+		hashListV2 := strings.Split(challengeV2Info.PieceHash, ",")
+		if len(hashListV2) < 1 {
+			return types.ChallengeResult{}, errors.New("get piece hashes less than 1")
+		}
+
+		pieceData, decodeErr := hex.DecodeString(challengeV2Info.PieceData)
+		if decodeErr != nil {
+			return types.ChallengeResult{}, err
+		}
+
+		result = types.ChallengeResult{
+			PieceData:     io.NopCloser(bytes.NewReader(pieceData)),
+			IntegrityHash: challengeV2Info.IntegrityHash,
+			PiecesHash:    hashListV2,
+		}
+	} else {
+		// fetch integrity hash
+		integrityHash := resp.Header.Get(types.HTTPHeaderIntegrityHash)
+		// fetch piece hashes
+		pieceHashes := resp.Header.Get(types.HTTPHeaderPieceHash)
+
+		if integrityHash == "" || pieceHashes == "" {
+			utils.CloseResponse(resp)
+			return types.ChallengeResult{}, errors.New("fail to fetch hash info")
+		}
+
+		hashList := strings.Split(pieceHashes, ",")
+		// min hash num equals one segment hash plus EC dataShards, parityShards
+		if len(hashList) < 1 {
+			return types.ChallengeResult{}, errors.New("get piece hashes less than 1")
+		}
+
+		result = types.ChallengeResult{
+			PieceData:     resp.Body,
+			IntegrityHash: integrityHash,
+			PiecesHash:    hashList,
+		}
 	}
 
-	hashList := strings.Split(pieceHashes, ",")
-	// min hash num equals one segment hash plus EC dataShards, parityShards
-	if len(hashList) < 1 {
-		return types.ChallengeResult{}, errors.New("get piece hashes less than 1")
-	}
-
-	result := types.ChallengeResult{
-		PieceData:     resp.Body,
-		IntegrityHash: integrityHash,
-		PiecesHash:    hashList,
-	}
 	return result, nil
 }
 

--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -193,7 +193,6 @@ func (c *Client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 		}
 
 		hashList := strings.Split(pieceHashes, ",")
-		// min hash num equals one segment hash plus EC dataShards, parityShards
 		if len(hashList) < 1 {
 			return types.ChallengeResult{}, errors.New("get piece hashes less than 1")
 		}

--- a/client/api_challenge.go
+++ b/client/api_challenge.go
@@ -88,12 +88,12 @@ func (c *Client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 
 	if opts.UseV2version {
 		sendOpt.adminInfo = AdminAPIInfo{
-			isAdminApi:   true,
+			isAdminAPI:   true,
 			adminVersion: types.AdminV2Version,
 		}
 	} else {
 		sendOpt.adminInfo = AdminAPIInfo{
-			isAdminApi:   true,
+			isAdminAPI:   true,
 			adminVersion: types.AdminV1Version,
 		}
 	}
@@ -163,7 +163,7 @@ func (c *Client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 
 		if challengeV2Info.IntegrityHash == "" || challengeV2Info.PieceHash == "" || challengeV2Info.PieceData == "" {
 			utils.CloseResponse(resp)
-			return types.ChallengeResult{}, errors.New("fail to fetch hash info")
+			return types.ChallengeResult{}, errors.New("the challenge info of response is empty")
 		}
 
 		hashListV2 := strings.Split(challengeV2Info.PieceHash, ",")
@@ -173,7 +173,7 @@ func (c *Client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 
 		pieceData, decodeErr := hex.DecodeString(challengeV2Info.PieceData)
 		if decodeErr != nil {
-			return types.ChallengeResult{}, err
+			return types.ChallengeResult{}, decodeErr
 		}
 
 		result = types.ChallengeResult{
@@ -182,9 +182,9 @@ func (c *Client) GetChallengeInfo(ctx context.Context, objectID string, pieceInd
 			PiecesHash:    hashListV2,
 		}
 	} else {
-		// fetch integrity hash
+		// fetch integrity hash from header
 		integrityHash := resp.Header.Get(types.HTTPHeaderIntegrityHash)
-		// fetch piece hashes
+		// fetch piece hashes from header
 		pieceHashes := resp.Header.Get(types.HTTPHeaderPieceHash)
 
 		if integrityHash == "" || pieceHashes == "" {

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -73,7 +73,6 @@ type Client struct {
 	offChainAuthOption *OffChainAuthOption
 	useWebsocketConn   bool
 	expireSeconds      uint64
-	needAuth           bool
 }
 
 // Option - Configurations for providing optional parameters for the Greenfield SDK Client.
@@ -184,6 +183,7 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 			}
 		}
 	}
+
 	return &c, nil
 }
 
@@ -304,7 +304,7 @@ type sendOptions struct {
 
 // AdminAPIInfo - the admin api info
 type AdminAPIInfo struct {
-	isAdminApi   bool // indicate if it is an admin api request
+	isAdminAPI   bool // indicate if it is an admin api request
 	adminVersion int  // indicate the version of admin api, the default value is 1
 }
 
@@ -407,7 +407,7 @@ func (c *Client) newRequest(ctx context.Context, method string, meta requestMeta
 		req.Header.Set(types.HTTPHeaderPieceIndex, strconv.Itoa(info.PieceIndex))
 	}
 
-	if adminAPIInfo.isAdminApi {
+	if adminAPIInfo.isAdminAPI {
 		if meta.txnMsg != "" {
 			req.Header.Set(types.HTTPHeaderUnsignedMsg, meta.txnMsg)
 		}
@@ -548,11 +548,12 @@ func (c *Client) generateURL(bucketName string, objectName string, relativePath 
 	}
 
 	var urlStr string
-	if adminInfo.isAdminApi {
+	if adminInfo.isAdminAPI {
 		var prefix string
-		if adminInfo.adminVersion == 1 {
+		// check the version and generate the url by the version
+		if adminInfo.adminVersion == types.AdminV1Version {
 			prefix = types.AdminURLPrefix + types.AdminURLV1Version
-		} else if adminInfo.adminVersion == 2 {
+		} else if adminInfo.adminVersion == types.AdminV2Version {
 			prefix = types.AdminURLPrefix + types.AdminURLV2Version
 		} else {
 			return nil, fmt.Errorf("invalid admin version %d", adminInfo.adminVersion)

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -73,6 +73,7 @@ type Client struct {
 	offChainAuthOption *OffChainAuthOption
 	useWebsocketConn   bool
 	expireSeconds      uint64
+	needAuth           bool
 }
 
 // Option - Configurations for providing optional parameters for the Greenfield SDK Client.
@@ -294,11 +295,17 @@ type requestMeta struct {
 
 // SendOptions -  options to use to send the http message
 type sendOptions struct {
-	method           string      // request method
-	body             interface{} // request body
-	disableCloseBody bool        // indicate whether to disable automatic calls to resp.Body.Close()
-	txnHash          string      // the transaction hash info
-	isAdminApi       bool        // indicate if it is an admin api request
+	method           string       // request method
+	body             interface{}  // request body
+	disableCloseBody bool         // indicate whether to disable automatic calls to resp.Body.Close()
+	txnHash          string       // the transaction hash info
+	adminInfo        AdminAPIInfo // the admin API info
+}
+
+// AdminAPIInfo - the admin api info
+type AdminAPIInfo struct {
+	isAdminApi   bool // indicate if it is an admin api request
+	adminVersion int  // indicate the version of admin api, the default value is 1
 }
 
 // downloadSegmentHook is hook for test
@@ -312,13 +319,13 @@ func DefaultDownloadSegmentHook(seg int64) error {
 
 // newRequest constructs the http request, set url, body and headers
 func (c *Client) newRequest(ctx context.Context, method string, meta requestMeta,
-	body interface{}, txnHash string, isAdminAPi bool, endpoint *url.URL,
+	body interface{}, txnHash string, adminAPIInfo AdminAPIInfo, endpoint *url.URL,
 ) (req *http.Request, err error) {
 	isVirtualHost := c.isVirtualHostStyleUrl(*endpoint, meta.bucketName)
 
 	// construct the target url
 	desURL, err := c.generateURL(meta.bucketName, meta.objectName, meta.urlRelPath,
-		meta.urlValues, isAdminAPi, endpoint, isVirtualHost)
+		meta.urlValues, adminAPIInfo, endpoint, isVirtualHost)
 	if err != nil {
 		log.Error().Msg(fmt.Sprintf("generate request url on SP: %s fail, err: %s", endpoint.String(), err))
 		return nil, err
@@ -400,7 +407,7 @@ func (c *Client) newRequest(ctx context.Context, method string, meta requestMeta
 		req.Header.Set(types.HTTPHeaderPieceIndex, strconv.Itoa(info.PieceIndex))
 	}
 
-	if isAdminAPi {
+	if adminAPIInfo.isAdminApi {
 		if meta.txnMsg != "" {
 			req.Header.Set(types.HTTPHeaderUnsignedMsg, meta.txnMsg)
 		}
@@ -499,7 +506,7 @@ func (c *Client) doAPI(ctx context.Context, req *http.Request, meta requestMeta,
 
 // sendReq sends the message via REST and handles the response
 func (c *Client) sendReq(ctx context.Context, metadata requestMeta, opt *sendOptions, endpoint *url.URL) (res *http.Response, err error) {
-	req, err := c.newRequest(ctx, opt.method, metadata, opt.body, opt.txnHash, opt.isAdminApi, endpoint)
+	req, err := c.newRequest(ctx, opt.method, metadata, opt.body, opt.txnHash, opt.adminInfo, endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -525,7 +532,7 @@ func (c *Client) SplitPartInfo(objectSize int64, configuredPartSize uint64) (tot
 
 // generateURL constructs the target request url based on the parameters
 func (c *Client) generateURL(bucketName string, objectName string, relativePath string,
-	queryValues url.Values, isAdminApi bool, endpoint *url.URL, isVirtualHost bool,
+	queryValues url.Values, adminInfo AdminAPIInfo, endpoint *url.URL, isVirtualHost bool,
 ) (*url.URL, error) {
 	host := endpoint.Host
 	scheme := endpoint.Scheme
@@ -541,8 +548,15 @@ func (c *Client) generateURL(bucketName string, objectName string, relativePath 
 	}
 
 	var urlStr string
-	if isAdminApi {
-		prefix := types.AdminURLPrefix + types.AdminURLVersion
+	if adminInfo.isAdminApi {
+		var prefix string
+		if adminInfo.adminVersion == 1 {
+			prefix = types.AdminURLPrefix + types.AdminURLV1Version
+		} else if adminInfo.adminVersion == 2 {
+			prefix = types.AdminURLPrefix + types.AdminURLV2Version
+		} else {
+			return nil, fmt.Errorf("invalid admin version %d", adminInfo.adminVersion)
+		}
 		urlStr = scheme + "://" + host + prefix + "/"
 	} else {
 		urlStr = scheme + "://" + host + "/"

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -121,6 +121,10 @@ func (c *Client) CreateObject(ctx context.Context, bucketName, objectName string
 		return "", err
 	}
 
+	for id, hash := range expectCheckSums {
+		fmt.Printf("id: %d, hash val: %s \n", id, string(hash))
+	}
+
 	var contentType string
 	if opts.ContentType != "" {
 		contentType = opts.ContentType
@@ -985,8 +989,11 @@ func (c *Client) GetCreateObjectApproval(ctx context.Context, createObjectMsg *s
 	}
 
 	sendOpt := sendOptions{
-		method:     http.MethodGet,
-		isAdminApi: true,
+		method: http.MethodGet,
+		adminInfo: AdminAPIInfo{
+			isAdminApi:   true,
+			adminVersion: types.AdminV1Version,
+		},
 	}
 
 	bucketName := createObjectMsg.BucketName

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -121,10 +121,6 @@ func (c *Client) CreateObject(ctx context.Context, bucketName, objectName string
 		return "", err
 	}
 
-	for id, hash := range expectCheckSums {
-		fmt.Printf("id: %d, hash val: %s \n", id, string(hash))
-	}
-
 	var contentType string
 	if opts.ContentType != "" {
 		contentType = opts.ContentType

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -991,7 +991,7 @@ func (c *Client) GetCreateObjectApproval(ctx context.Context, createObjectMsg *s
 	sendOpt := sendOptions{
 		method: http.MethodGet,
 		adminInfo: AdminAPIInfo{
-			isAdminApi:   true,
+			isAdminAPI:   true,
 			adminVersion: types.AdminV1Version,
 		},
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/bnb-chain/greenfield v1.0.0
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228
 	github.com/cometbft/cometbft v0.37.2
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/bnb-chain/greenfield-cometbft v1.0.0 h1:0r6hOJWD/+es0gxP/exKuN/krgXAr
 github.com/bnb-chain/greenfield-cometbft v1.0.0/go.mod h1:f35mk/r5ab6yvzlqEWZt68LfUje68sYgMpVlt2CUYMk=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f h1:zJvB2wCd80DQ9Nh/ZNQiP8MrHygSpDoav7OzHyIi/pM=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230830120314-a54ffd6da39f/go.mod h1:it3JJVHeG9Wp4QED2GkY/7V9Qo3BuPdoC5/4/U6ecJM=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228 h1:WywBaew30hZuqDTOQbkRV3uBg6XHjNIE1s3AXVXbG+8=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228/go.mod h1:K9jK80fbahciC+FAvrch8Qsbw9ZkvVgjfKsqrzPTAVA=
 github.com/bnb-chain/greenfield-cosmos-sdk v1.0.0 h1:hWRvYunA4Um19gwL1SVfMwN9l431ROC7XZ+A5+xM/Bk=
 github.com/bnb-chain/greenfield-cosmos-sdk v1.0.0/go.mod h1:y3hDhQhil5hMIhwBTpu07RZBF30ZITkoE+GHhVZChtY=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20230816082903-b48770f5e210 h1:GHPbV2bC+gmuO6/sG0Tm8oGal3KKSRlyE+zPscDjlA8=

--- a/types/const.go
+++ b/types/const.go
@@ -40,8 +40,11 @@ const (
 	EmptyStringSHA256       = `e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855`
 	Iso8601DateFormatSecond = "2006-01-02T15:04:05Z"
 
-	AdminURLPrefix  = "/greenfield/admin"
-	AdminURLVersion = "/v1"
+	AdminURLPrefix    = "/greenfield/admin"
+	AdminURLV1Version = "/v1"
+	AdminURLV2Version = "/v2"
+	AdminV1Version    = 1
+	AdminV2Version    = 2
 
 	CreateObjectAction  = "CreateObject"
 	CreateBucketAction  = "CreateBucket"

--- a/types/list.go
+++ b/types/list.go
@@ -54,6 +54,18 @@ type UploadOffset struct {
 	Offset  uint64   `xml:"Offset"`       // Offset defines the offset info of resumable uploading object
 }
 
+// ChallengeV2Result indicates the response info of challenge v2 API
+type ChallengeV2Result struct {
+	XMLName         xml.Name `xml:"GetChallengeInfo"`
+	Version         string   `xml:"version,attr"`
+	ObjectID        string   `xml:"ObjectID"`        // ObjectID defines the object id of the challenge request
+	RedundancyIndex string   `xml:"RedundancyIndex"` // RedundancyIndex defines the redundancy index of the challenge request
+	PieceIndex      string   `xml:"PieceIndex"`      // PieceIndex defines the piece index of the challenge request
+	IntegrityHash   string   `xml:"IntegrityHash"`   // IntegrityHash defines the integrity hash of the object
+	PieceHash       string   `xml:"PieceHash"`       // PieceHash defines the return piece hashes of the object
+	PieceData       string   `xml:"PieceData"`       // PieceData defines the return piece data of challenge request
+}
+
 // ListObjectsResult indicates the result of listObjects API.
 type ListObjectsResult struct {
 	// Objects defines the list of object

--- a/types/option.go
+++ b/types/option.go
@@ -226,8 +226,9 @@ type GetObjectOptions struct {
 
 // GetChallengeInfoOptions contains the options for querying challenge data.
 type GetChallengeInfoOptions struct {
-	Endpoint  string // Endpoint indicates the endpoint of sp
-	SPAddress string // SPAddress indicates the HEX-encoded string of the sp address to be challenged.
+	Endpoint     string // Endpoint indicates the endpoint of sp
+	SPAddress    string // SPAddress indicates the HEX-encoded string of the sp address to be challenged.
+	UseV2version bool   // UseV2version indicates whether using of the v2 version get-challenge API
 }
 
 // GetSecondaryPieceOptions contains the options for `GetSecondaryPiece` API.


### PR DESCRIPTION
### Description

support option to switch v2 version of challenge API of GetChallengeInfo to fix challenge API issue . The GetChallengeInfo will stay  compatible with the old version.

The V2 challenge API  will return the XML body with the intergrityHash , pieceHashes and piece data info


### Rationale

the new challenge API  will change protocol

### Example
// if  need use V2 version , set the option of UseV2version as true
// default using V1 version API to keep  compatible
`GetChallengeInfo( types.GetChallengeInfoOptions{UseV2version : true} )`

### Changes

Notable changes:
* support v2 version of challenge API  