### PR TITLE
feat: shuffle the result of `ListStorageProviders`

### DIFF
--- a/client/api_sp.go
+++ b/client/api_sp.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	math2 "math"
+	"math/rand"
 	"strings"
 	"time"
 
@@ -96,6 +97,10 @@ func (c *Client) ListStorageProviders(ctx context.Context, isInService bool) ([]
 		}
 		spInfoList = append(spInfoList, *info)
 	}
+
+	rand.Shuffle(len(spInfoList), func(i, j int) {
+		spInfoList[i], spInfoList[j] = spInfoList[j], spInfoList[i]
+	})
 
 	return spInfoList, nil
 }


### PR DESCRIPTION
### Description

This pr is to optimize the `ListStorageProviders` method

### Rationale

To prevent traffic from being concentrated on the first sp, we randomly sorted the returned lists

### Changes

Notable changes:
* shuffle the result of `ListStorageProviders` before return