### PR TITLE
feat: add GetObjectMeta

### DIFF
--- a/client/api_object.go
+++ b/client/api_object.go
@@ -58,6 +58,7 @@ type IObjectClient interface {
 	GetObjectResumableUploadOffset(ctx context.Context, bucketName, objectName string) (uint64, error)
 	ListObjectsByObjectID(ctx context.Context, objectIds []uint64, opts types.EndPointOptions) (types.ListObjectsByObjectIDResponse, error)
 	ListObjectPolicies(ctx context.Context, objectName, bucketName string, actionType uint32, opts types.ListObjectPoliciesOptions) (types.ListObjectPoliciesResponse, error)
+	GetObjectMeta(ctx context.Context, bucketName, objectName string) (types.ObjectMeta, error)
 }
 
 // GetRedundancyParams query and return the data shards, parity shards and segment size of redundancy
@@ -1349,4 +1350,58 @@ func (c *Client) ListObjectPolicies(ctx context.Context, objectName, bucketName 
 	}
 
 	return policies, nil
+}
+
+// GetObjectMeta return the object meta info
+func (c *Client) GetObjectMeta(ctx context.Context, bucketName, objectName string) (types.ObjectMeta, error) {
+	if err := s3util.CheckValidBucketName(bucketName); err != nil {
+		return types.ObjectMeta{}, err
+	}
+
+	if err := s3util.CheckValidObjectName(objectName); err != nil {
+		return types.ObjectMeta{}, err
+	}
+
+	reqMeta := requestMeta{
+		bucketName: bucketName,
+		objectName: objectName,
+		urlValues: url.Values{
+			"object-meta": []string{""},
+		},
+	}
+
+	sendOpt := sendOptions{
+		method:           http.MethodGet,
+		disableCloseBody: true,
+	}
+
+	endpoint, err := c.getSPUrlByBucket(bucketName)
+	if err != nil {
+		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed,  err: %s", bucketName, err.Error()))
+		return types.ObjectMeta{}, err
+	}
+
+	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, endpoint)
+	if err != nil {
+		return types.ObjectMeta{}, err
+	}
+	defer utils.CloseResponse(resp)
+
+	// unmarshal the xml content from response body
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, resp.Body)
+	if err != nil {
+		log.Error().Msg("the meta of object in user's bucket:" + bucketName + " failed: " + err.Error())
+		return types.ObjectMeta{}, err
+	}
+
+	objectMetaResp := types.GetObjectMetaResponse{}
+	bufStr := buf.String()
+	err = xml.Unmarshal([]byte(bufStr), &objectMetaResp)
+	if err != nil && objectMetaResp.Object == nil {
+		log.Error().Msg("the meta of object in user's bucket:" + bucketName + " failed: " + err.Error())
+		return types.ObjectMeta{}, err
+	}
+
+	return *objectMetaResp.Object, nil
 }

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -204,6 +204,12 @@ func (s *StorageTestSuite) Test_Object() {
 	}
 	wg.Wait()
 
+	s.T().Log("---> GetObjectMeta <---")
+	meta1, err := s.Client.GetObjectMeta(s.ClientContext, bucketName, objectName)
+	s.Require().NoError(err)
+	s.Require().Equal(objectName, meta1.ObjectInfo.ObjectName)
+	s.Require().Equal(bucketName, meta1.ObjectInfo.BucketName)
+
 	expectQuotaUsed := int(objectSize) * concurrentNumber * downloadCount
 	quota1, err := s.Client.GetBucketReadQuota(s.ClientContext, bucketName)
 	s.Require().NoError(err)

--- a/examples/storage.go
+++ b/examples/storage.go
@@ -73,6 +73,11 @@ func main() {
 		handleErr(errors.New("download content not same"), "GetObject")
 	}
 
+	// get object meta
+	objectMeta, err := cli.GetObjectMeta(ctx, bucketName, objectName)
+	handleErr(err, "GetObjectMeta")
+	log.Printf("get object meta %s successfully, CreateTxHash %s \n", objectName, objectMeta.CreateTxHash)
+
 	// list objects
 	objects, err := cli.ListObjects(ctx, bucketName, types.ListObjectsOptions{
 		ShowRemovedObject: false, Delimiter: "", MaxKeys: 100, Endpoint: httpsAddr, SPAddress: "",

--- a/types/list.go
+++ b/types/list.go
@@ -418,3 +418,7 @@ type PolicyMeta struct {
 	// ExpirationTime defines the expiration time of permission
 	ExpirationTime int64 `xml:"ExpirationTime"`
 }
+
+type GetObjectMetaResponse struct {
+	Object *ObjectMeta `xml:"Object"`
+}


### PR DESCRIPTION
### Description

Add GetObjectMeta (API Spec: https://docs.bnbchain.org/greenfield-docs/docs/api/storage-provider-rest/get_object_meta)

### Rationale

In some cases, we could use the ObjectName to get the CreateObject TxHash

### Example

`GetObjectMeta(ctx context.Context, bucketName, objectName string) (types.ObjectMeta, error)`