### PR TITLE
fix: ListObjectPoliciesResponse unmarshal failed

### DIFF
--- a/client/api_object.go
+++ b/client/api_object.go
@@ -1285,7 +1285,23 @@ func (c *Client) ListObjectsByObjectID(ctx context.Context, objectIds []uint64, 
 //
 // - bucketName: The bucket name identifies the bucket.
 //
-// - actionType: The action type defines the requested action type of permission.
+//   - actionType: The action type defines the requested action type of permission.
+//     | Value | Description                |
+//     | ----- | -------------------------- |
+//     | 0     | ACTION_UNSPECIFIED         |89
+//     | 1     | ACTION_UPDATE_BUCKET_INFO  |
+//     | 2     | ACTION_DELETE_BUCKET       |
+//     | 3     | ACTION_CREATE_OBJECT       |
+//     | 4     | ACTION_DELETE_OBJECT       |
+//     | 5     | ACTION_COPY_OBJECT         |
+//     | 6     | ACTION_GET_OBJECT          |
+//     | 7     | ACTION_EXECUTE_OBJECT      |
+//     | 8     | ACTION_LIST_OBJECT         |
+//     | 9     | ACTION_UPDATE_GROUP_MEMBER |
+//     | 10    | ACTION_DELETE_GROUP        |
+//     | 11    | ACTION_UPDATE_OBJECT_INFO  |
+//     | 12    | ACTION_UPDATE_GROUP_EXTRA  |
+//     | 99    | ACTION_TYPE_ALL            |
 //
 // - opts: The options to set the meta to list object policies
 //
@@ -1339,7 +1355,7 @@ func (c *Client) ListObjectPolicies(ctx context.Context, objectName, bucketName 
 
 	policies := types.ListObjectPoliciesResponse{}
 	bufStr := buf.String()
-	err = xml.Unmarshal([]byte(bufStr), &policies.Policies)
+	err = xml.Unmarshal([]byte(bufStr), &policies)
 	if err != nil {
 		log.Error().Msgf("the list object policies in bucket name:%s, object name:%s failed: %s", bucketName, objectName, err.Error())
 		return types.ListObjectPoliciesResponse{}, err

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/bnb-chain/greenfield-go-sdk/types"
 	types2 "github.com/bnb-chain/greenfield/sdk/types"
 	storageTestUtil "github.com/bnb-chain/greenfield/testutil/storage"
+	"github.com/bnb-chain/greenfield/types/resource"
 	permTypes "github.com/bnb-chain/greenfield/x/permission/types"
 	spTypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
@@ -236,6 +237,12 @@ func (s *StorageTestSuite) Test_Object() {
 	objectPolicy, err := s.Client.GetObjectPolicy(s.ClientContext, bucketName, objectName, principal.GetAddress().String())
 	s.Require().NoError(err)
 	s.T().Logf("get object policy:%s\n", objectPolicy.String())
+
+	s.T().Log("--->  ListObjectPolicies <---")
+	objectPolicies, err := s.Client.ListObjectPolicies(s.ClientContext, objectName, bucketName, uint32(permTypes.ACTION_GET_OBJECT), types.ListObjectPoliciesOptions{})
+	s.Require().NoError(err)
+	s.Require().Equal(resource.RESOURCE_TYPE_OBJECT.String(), resource.ResourceType_name[objectPolicies.Policies[0].ResourceType])
+	s.T().Logf("list object policies principal type:%d principal value:%s \n", objectPolicies.Policies[0].PrincipalType, objectPolicies.Policies[0].PrincipalValue)
 
 	s.T().Log("---> DeleteObjectPolicy <---")
 


### PR DESCRIPTION
### Description

fix ListObjectPoliciesResponse unmarshal failed bug

### Rationale

![image](https://github.com/bnb-chain/greenfield-go-sdk/assets/122767193/b74afe09-b722-4f5c-86ff-43d5ea76cece)

### Example

N/A

### Changes

Notable changes:
* fix ListObjectPoliciesResponse unmarshal failed bug