### PR TITLE
fix: support parsing content type when creating object

### DIFF
--- a/client/api_object.go
+++ b/client/api_object.go
@@ -115,8 +115,17 @@ func (c *Client) CreateObject(ctx context.Context, bucketName, objectName string
 		return "", err
 	}
 
+	// Read a small chunk to detect MIME type
+	peeker := make([]byte, types.BytesToReadForMIME)
+	n, err := reader.Read(peeker)
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+
+	// Concatenate the peeked data with the original reader
+	combinedReader := io.MultiReader(bytes.NewReader(peeker[:n]), reader)
 	// compute hash root of payload
-	expectCheckSums, size, redundancyType, err := c.ComputeHashRoots(reader, opts.IsSerialComputeMode)
+	expectCheckSums, size, redundancyType, err := c.ComputeHashRoots(combinedReader, opts.IsSerialComputeMode)
 	if err != nil {
 		return "", err
 	}
@@ -125,9 +134,9 @@ func (c *Client) CreateObject(ctx context.Context, bucketName, objectName string
 	if opts.ContentType != "" {
 		contentType = opts.ContentType
 	} else {
-		contentType = types.ContentDefault
+		contentType = http.DetectContentType(peeker[:n])
 	}
-
+	
 	var visibility storageTypes.VisibilityType
 	if opts.Visibility == storageTypes.VISIBILITY_TYPE_UNSPECIFIED {
 		visibility = storageTypes.VISIBILITY_TYPE_INHERIT // set default visibility type

--- a/types/const.go
+++ b/types/const.go
@@ -72,4 +72,5 @@ const (
 
 	WaitTxContextTimeOut = 1 * time.Second
 	DefaultExpireSeconds = 1000
+	BytesToReadForMIME   = 512
 )


### PR DESCRIPTION
### Description

when uploading files, we can parse the mime type , and set the content type of the object as the mime type

### Rationale

set the accurate content type

### Example

add an example CLI or API response...

### Changes

Notable changes:
* add each change in a bullet point here
* ...