### PR TITLE
feat: add proto message info to ObjectDetail type so that it can be marshalled into json by using jsonpb

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   GreenfieldTag: develop
-  GreenfieldStorageProviderTag: feat-add-tags
+  GreenfieldStorageProviderTag: develop
   GOPRIVATE: github.com/bnb-chain
   GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
   MYSQL_USER: root

--- a/types/types.go
+++ b/types/types.go
@@ -6,10 +6,11 @@ import (
 	"net/url"
 	"time"
 
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
 	spTypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
 	"github.com/bnb-chain/greenfield/x/virtualgroup/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -27,8 +28,8 @@ type ObjectStat struct {
 
 // ObjectDetail contains the detailed info of the object stored on Greenfield.
 type ObjectDetail struct {
-	ObjectInfo         *storagetypes.ObjectInfo
-	GlobalVirtualGroup *types.GlobalVirtualGroup
+	ObjectInfo         *storagetypes.ObjectInfo  `protobuf:"bytes,1,opt,name=object_info" json:"object_info,omitempty"`
+	GlobalVirtualGroup *types.GlobalVirtualGroup `protobuf:"bytes,2,opt,name=global_virtual_group" json:"global_virtual_group,omitempty"`
 }
 
 // QueryPieceInfo indicates the challenge or recovery object piece info.

--- a/types/types.go
+++ b/types/types.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	proto "github.com/cosmos/gogoproto/proto"
 
 	spTypes "github.com/bnb-chain/greenfield/x/sp/types"
 	storagetypes "github.com/bnb-chain/greenfield/x/storage/types"
@@ -31,6 +32,10 @@ type ObjectDetail struct {
 	ObjectInfo         *storagetypes.ObjectInfo  `protobuf:"bytes,1,opt,name=object_info" json:"object_info,omitempty"`
 	GlobalVirtualGroup *types.GlobalVirtualGroup `protobuf:"bytes,2,opt,name=global_virtual_group" json:"global_virtual_group,omitempty"`
 }
+
+func (m *ObjectDetail) ProtoMessage()  {}
+func (m *ObjectDetail) Reset()         { *m = ObjectDetail{} }
+func (m *ObjectDetail) String() string { return proto.CompactTextString(m) }
 
 // QueryPieceInfo indicates the challenge or recovery object piece info.
 // If it is primary sp, the RedundancyIndex value should be -1， else it indicates the index of secondary sp.


### PR DESCRIPTION
### Description

feat: add proto message info to ObjectDetail type so that it can be marshalled into json by using jsonpb

### Rationale

In clients (e.g. greenfield-cmd), they might want to use jsonpb to marshal the "ObjectDetail" type returned by go-sdk. Because the fields in "ObjectDetail" type are all proto messages. 

### Example

N/A
### Changes

Notable changes:
* protobuf annotations
* add necessary methods of proto message type