### PR TITLE
fix: remove tags field when creating object/group/bucket

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,8 +12,8 @@ on:
       - develop
 
 env:
-  GreenfieldTag: develop
-  GreenfieldStorageProviderTag: develop
+  GreenfieldTag: master
+  GreenfieldStorageProviderTag: fix-adapt-new-tag
   GOPRIVATE: github.com/bnb-chain
   GH_ACCESS_TOKEN: ${{ secrets.GH_TOKEN }}
   MYSQL_USER: root

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -648,7 +648,7 @@ func (s *StorageTestSuite) Test_Group_with_Tag() {
 	headResult, err := s.Client.HeadGroup(s.ClientContext, groupName, groupOwner.String())
 	s.Require().NoError(err)
 	s.Require().Equal(groupName, headResult.GroupName)
-	s.Require().Equal(tags, &headResult.Tags)
+	s.Require().Equal(tags, *headResult.Tags)
 }
 
 func (s *StorageTestSuite) Test_Group_without_Tag() {
@@ -680,7 +680,7 @@ func (s *StorageTestSuite) Test_Group_without_Tag() {
 	headResult, err = s.Client.HeadGroup(s.ClientContext, groupName, groupOwner.String())
 	s.Require().NoError(err)
 	s.Require().Equal(groupName, headResult.GroupName)
-	s.Require().Equal(tags, &headResult.Tags)
+	s.Require().Equal(tags, *headResult.Tags)
 }
 
 func (s *StorageTestSuite) Test_Bucket_with_Tag() {
@@ -704,6 +704,6 @@ func (s *StorageTestSuite) Test_Bucket_with_Tag() {
 	if err == nil {
 		s.Require().Equal(bucketInfo.Visibility, storageTypes.VISIBILITY_TYPE_PRIVATE)
 		s.Require().Equal(bucketInfo.ChargedReadQuota, chargedQuota)
-		s.Require().Equal(tags, &bucketInfo.Tags)
+		s.Require().Equal(tags, *bucketInfo.Tags)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,12 @@ go 1.20
 require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
-	github.com/bnb-chain/greenfield v1.0.2-0.20231205022545-1760620afde0
+	github.com/bnb-chain/greenfield v1.2.1-0.20231221015040-11071a6ee95b
 	github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228
 	github.com/cometbft/cometbft v0.37.2
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3
+	github.com/cosmos/gogoproto v1.4.10
 	github.com/ethereum/go-ethereum v1.10.26
 	github.com/prysmaticlabs/prysm v0.0.0-20220124113610-e26cde5e091b
 	github.com/rs/zerolog v1.29.1
@@ -40,7 +41,6 @@ require (
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.3 // indirect
 	github.com/cosmos/go-bip39 v1.0.0 // indirect
-	github.com/cosmos/gogoproto v1.4.10 // indirect
 	github.com/cosmos/iavl v0.20.0 // indirect
 	github.com/cosmos/ledger-cosmos-go v0.13.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -152,8 +152,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816 h1:41iFGWnSlI2gVpmOtVTJZNodLdLQLn/KsJqFvXwnd/s=
 github.com/bgentry/speakeasy v0.1.1-0.20220910012023-760eaf8b6816/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
-github.com/bnb-chain/greenfield v1.0.2-0.20231205022545-1760620afde0 h1:dnwMwE6IVg54Jzeaa8fN+BbLBJWVPcURs/2hKZipRuk=
-github.com/bnb-chain/greenfield v1.0.2-0.20231205022545-1760620afde0/go.mod h1:hF7FWoXDx3ddImH3OGUNrlTdwkWKNIYUOGL+Yrq0nsg=
+github.com/bnb-chain/greenfield v1.2.1-0.20231221015040-11071a6ee95b h1:UBgGcMo5Sf+sCMqkB2zu0sfuuMGBQ+5Ib1QIJ0sLXes=
+github.com/bnb-chain/greenfield v1.2.1-0.20231221015040-11071a6ee95b/go.mod h1:p8M80v/a6mRm+ZPbW8Hfjc1npWktO6BDtebr9/8ETRs=
 github.com/bnb-chain/greenfield-cometbft v1.1.0 h1:jqnkDWIZW6f/rUn5/pE26YZMT9xzpp0qTswNy7FPRBk=
 github.com/bnb-chain/greenfield-cometbft v1.1.0/go.mod h1:NZ2/ZJK2HYe3++0CsPiw4LTG6UrC6pH7fQ3VOz6pqJw=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=


### PR DESCRIPTION
### Description

fix: remove tags field when creating object/group/bucket

### Rationale

Adapting changes from greenfield chain https://github.com/bnb-chain/greenfield/pull/543
### Example

N/A

### Changes

Notable changes:
* remove tags field when creating object/group/bucket
* Use multi msg when creating object/group/bucket if tags are needed.