### PR TITLE
feat: update get object for speed

### DIFF
--- a/client/api_client.go
+++ b/client/api_client.go
@@ -96,8 +96,8 @@ type Option struct {
 	UseWebSocketConn bool
 	// ExpireSeconds indicates the number of seconds after which the authentication of the request sent to the SP will become invalid，the default value is 1000.
 	ExpireSeconds uint64
-	// SpEndpoint indicates the endpoint of sp
-	SpEndpoint string
+	// Endpoint indicates the endpoint of sp
+	Endpoint string
 }
 
 // OffChainAuthOption - The optional configurations for off-chain-auth.
@@ -134,21 +134,16 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 		cc  *sdkclient.GreenfieldClient
 		err error
 	)
-	fmt.Println("sdkclient.NewGreenfieldClient starts: ", time.Now())
 	if option.UseWebSocketConn {
 		cc, err = sdkclient.NewGreenfieldClient(endpoint, chainID, sdkclient.WithWebSocketClient())
 	} else {
 		cc, err = sdkclient.NewGreenfieldClient(endpoint, chainID)
 	}
-	fmt.Println("sdkclient.NewGreenfieldClient ends: ", time.Now())
-
 	if err != nil {
 		return nil, err
 	}
 	if option.DefaultAccount != nil {
-		fmt.Println("cc.SetKeyManager starts: ", time.Now())
 		cc.SetKeyManager(option.DefaultAccount.GetKeyManager())
-		fmt.Println("cc.SetKeyManager ends: ", time.Now())
 	}
 
 	if option.ExpireSeconds > httplib.MaxExpiryAgeInSec {
@@ -167,8 +162,7 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 		expireSeconds:    option.ExpireSeconds,
 	}
 
-	fmt.Println("c.refreshStorageProviders starts: ", time.Now())
-	if option.SpEndpoint == "" {
+	if option.Endpoint == "" {
 		// fetch sp endpoints info from chain
 		err = c.refreshStorageProviders(context.Background())
 
@@ -176,8 +170,6 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 			return nil, err
 		}
 	}
-	fmt.Println("c.refreshStorageProviders ends: ", time.Now())
-
 	// register off-chain-auth pubkey to all sps
 	if option.OffChainAuthOption != nil {
 		if option.OffChainAuthOption.Seed == "" || option.OffChainAuthOption.Domain == "" {

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -96,6 +96,8 @@ type Option struct {
 	UseWebSocketConn bool
 	// ExpireSeconds indicates the number of seconds after which the authentication of the request sent to the SP will become invalid，the default value is 1000.
 	ExpireSeconds uint64
+	// SpEndpoint indicates the endpoint of sp
+	SpEndpoint string
 }
 
 // OffChainAuthOption - The optional configurations for off-chain-auth.
@@ -166,13 +168,16 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 	}
 
 	fmt.Println("c.refreshStorageProviders starts: ", time.Now())
-	// fetch sp endpoints info from chain
-	//err = c.refreshStorageProviders(context.Background())
+	if option.SpEndpoint == "" {
+		// fetch sp endpoints info from chain
+		err = c.refreshStorageProviders(context.Background())
+
+		if err != nil {
+			return nil, err
+		}
+	}
 	fmt.Println("c.refreshStorageProviders ends: ", time.Now())
 
-	if err != nil {
-		return nil, err
-	}
 	// register off-chain-auth pubkey to all sps
 	if option.OffChainAuthOption != nil {
 		if option.OffChainAuthOption.Seed == "" || option.OffChainAuthOption.Domain == "" {

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -73,8 +73,8 @@ type Client struct {
 	offChainAuthOption *OffChainAuthOption
 	useWebsocketConn   bool
 	expireSeconds      uint64
-	// forceToUseSpecifiedSpEndpointForDownloadOnly indicates a fixed endpoint of sp and shall only be used by get object cmd.
-	// Any other api shall not use this parameter.
+	// forceToUseSpecifiedSpEndpointForDownloadOnly indicates a fixed SP endpoint to which to send the download request
+	// If this option is set, the client can only make download requests, and can only download from the fixed endpoint
 	forceToUseSpecifiedSpEndpointForDownloadOnly *url.URL
 }
 
@@ -99,8 +99,8 @@ type Option struct {
 	UseWebSocketConn bool
 	// ExpireSeconds indicates the number of seconds after which the authentication of the request sent to the SP will become invalid，the default value is 1000.
 	ExpireSeconds uint64
-	// ForceToUseSpecifiedSpEndpointForDownloadOnly indicates a fixed endpoint of sp and shall only be used by get object cmd.
-	// Any other api shall not use this parameter.
+	// ForceToUseSpecifiedSpEndpointForDownloadOnly indicates a fixed SP endpoint to which to send the download request
+	// If this option is set, the client can only make download requests, and can only download from the fixed endpoint
 	ForceToUseSpecifiedSpEndpointForDownloadOnly string
 }
 

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -187,15 +187,11 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 			return nil, err
 		}
 	}
-
-	if option.OffChainAuthOption != nil && option.ForceToUseSpecifiedSpEndpointForDownloadOnly != "" {
-		errMessage := "forceToUseSpecifiedSpEndpointForDownloadOnly option does not support OffChainAuthOption, please adjust option inputs and try again"
-		log.Error().Msg(errMessage)
-		return nil, errors.New(errMessage)
-	}
-
 	// register off-chain-auth pubkey to all sps
 	if option.OffChainAuthOption != nil {
+		if option.ForceToUseSpecifiedSpEndpointForDownloadOnly != "" {
+			return nil, errors.New("forceToUseSpecifiedSpEndpointForDownloadOnly option does not support OffChainAuthOption, please adjust option inputs and try again")
+		}
 		if option.OffChainAuthOption.Seed == "" || option.OffChainAuthOption.Domain == "" {
 			return nil, errors.New("seed and domain can't be empty in OffChainAuthOption")
 		}

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -167,7 +167,7 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 
 	fmt.Println("c.refreshStorageProviders starts: ", time.Now())
 	// fetch sp endpoints info from chain
-	err = c.refreshStorageProviders(context.Background())
+	//err = c.refreshStorageProviders(context.Background())
 	fmt.Println("c.refreshStorageProviders ends: ", time.Now())
 
 	if err != nil {

--- a/client/api_client.go
+++ b/client/api_client.go
@@ -132,16 +132,21 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 		cc  *sdkclient.GreenfieldClient
 		err error
 	)
+	fmt.Println("sdkclient.NewGreenfieldClient starts: ", time.Now())
 	if option.UseWebSocketConn {
 		cc, err = sdkclient.NewGreenfieldClient(endpoint, chainID, sdkclient.WithWebSocketClient())
 	} else {
 		cc, err = sdkclient.NewGreenfieldClient(endpoint, chainID)
 	}
+	fmt.Println("sdkclient.NewGreenfieldClient ends: ", time.Now())
+
 	if err != nil {
 		return nil, err
 	}
 	if option.DefaultAccount != nil {
+		fmt.Println("cc.SetKeyManager starts: ", time.Now())
 		cc.SetKeyManager(option.DefaultAccount.GetKeyManager())
+		fmt.Println("cc.SetKeyManager ends: ", time.Now())
 	}
 
 	if option.ExpireSeconds > httplib.MaxExpiryAgeInSec {
@@ -160,8 +165,10 @@ func New(chainID string, endpoint string, option Option) (IClient, error) {
 		expireSeconds:    option.ExpireSeconds,
 	}
 
+	fmt.Println("c.refreshStorageProviders starts: ", time.Now())
 	// fetch sp endpoints info from chain
 	err = c.refreshStorageProviders(context.Background())
+	fmt.Println("c.refreshStorageProviders ends: ", time.Now())
 
 	if err != nil {
 		return nil, err

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -507,7 +507,7 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string,
 		disableCloseBody: true,
 	}
 
-	var endpoint *url.URL
+	var endpoint = url.URL{}
 	//endpoint, err := c.getSPUrlByBucket(bucketName)
 	endpoint.Scheme = "https"
 	endpoint.Host = "gnfd-testnet-sp2.bnbchain.org"
@@ -516,7 +516,7 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string,
 	//	return nil, types.ObjectStat{}, err
 	//}
 
-	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, endpoint)
+	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, &endpoint)
 	if err != nil {
 		return nil, types.ObjectStat{}, err
 	}

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -510,19 +510,8 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string,
 
 	var endpoint *url.URL
 
-	if opts.Endpoint != "" {
-		var useHttps bool
-		if strings.Contains(opts.Endpoint, "https") {
-			useHttps = true
-		} else {
-			useHttps = c.secure
-		}
-
-		endpoint, err = utils.GetEndpointURL(opts.Endpoint, useHttps)
-		if err != nil {
-			log.Error().Msg(fmt.Sprintf("fetch endpoint from opts %s fail:%v", opts.Endpoint, err))
-			return nil, types.ObjectStat{}, err
-		}
+	if c.forceToUseSpecifiedSpEndpointForDownloadOnly != nil {
+		endpoint = c.forceToUseSpecifiedSpEndpointForDownloadOnly
 	} else {
 		endpoint, err = c.getSPUrlByBucket(bucketName)
 

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -509,10 +509,6 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string,
 	}
 
 	var endpoint *url.URL
-	//if opts.Endpoint != "" {
-	//	endpoint.Scheme = "https"
-	//	endpoint.Host = "gnfd-testnet-sp3.nodereal.io"
-	//}
 
 	if opts.Endpoint != "" {
 		var useHttps bool

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -510,7 +510,7 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string,
 	var endpoint = url.URL{}
 	//endpoint, err := c.getSPUrlByBucket(bucketName)
 	endpoint.Scheme = "https"
-	endpoint.Host = "gnfd-testnet-sp2.bnbchain.org"
+	endpoint.Host = "gnfd-testnet-sp3.nodereal.io"
 	//if err != nil {
 	//	log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed,  err: %s", bucketName, err.Error()))
 	//	return nil, types.ObjectStat{}, err

--- a/client/api_object.go
+++ b/client/api_object.go
@@ -507,11 +507,14 @@ func (c *Client) GetObject(ctx context.Context, bucketName, objectName string,
 		disableCloseBody: true,
 	}
 
-	endpoint, err := c.getSPUrlByBucket(bucketName)
-	if err != nil {
-		log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed,  err: %s", bucketName, err.Error()))
-		return nil, types.ObjectStat{}, err
-	}
+	var endpoint *url.URL
+	//endpoint, err := c.getSPUrlByBucket(bucketName)
+	endpoint.Scheme = "https"
+	endpoint.Host = "gnfd-testnet-sp2.bnbchain.org"
+	//if err != nil {
+	//	log.Error().Msg(fmt.Sprintf("route endpoint by bucket: %s failed,  err: %s", bucketName, err.Error()))
+	//	return nil, types.ObjectStat{}, err
+	//}
 
 	resp, err := c.sendReq(ctx, reqMeta, &sendOpt, endpoint)
 	if err != nil {

--- a/e2e/e2e_storage_test.go
+++ b/e2e/e2e_storage_test.go
@@ -844,3 +844,59 @@ func (s *StorageTestSuite) Test_Object_And_Set_Tag() {
 		s.Require().Equal(tags, *objectDetail.ObjectInfo.Tags)
 	}
 }
+
+func (s *StorageTestSuite) Test_Get_Object_With_ForcedSpEndpoint() {
+	bucketName := storageTestUtil.GenRandomBucketName()
+	objectName := storageTestUtil.GenRandomObjectName()
+
+	s.T().Logf("BucketName:%s, objectName: %s", bucketName, objectName)
+
+	bucketTx, err := s.Client.CreateBucket(s.ClientContext, bucketName, s.PrimarySP.OperatorAddress, types.CreateBucketOptions{})
+	s.Require().NoError(err)
+
+	_, err = s.Client.WaitForTx(s.ClientContext, bucketTx)
+	s.Require().NoError(err)
+
+	bucketInfo, err := s.Client.HeadBucket(s.ClientContext, bucketName)
+	s.Require().NoError(err)
+	if err == nil {
+		s.Require().Equal(bucketInfo.Visibility, storageTypes.VISIBILITY_TYPE_PRIVATE)
+	}
+
+	var buffer bytes.Buffer
+	line := `1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,1234567890,123456789012`
+	// Create 1MiB content where each line contains 1024 characters.
+	for i := 0; i < 1024*300; i++ {
+		buffer.WriteString(fmt.Sprintf("[%05d] %s\n", i, line))
+	}
+
+	s.T().Log("---> CreateObject and HeadObject <---")
+	objectTx, err := s.Client.CreateObject(s.ClientContext, bucketName, objectName, bytes.NewReader(buffer.Bytes()),
+		types.CreateObjectOptions{})
+	s.Require().NoError(err)
+	_, err = s.Client.WaitForTx(s.ClientContext, objectTx)
+	s.Require().NoError(err)
+
+	time.Sleep(5 * time.Second)
+
+	s.Require().NoError(err)
+
+	s.T().Log("---> client.New with ForceToUseSpecifiedSpEndpointForDownloadOnly option filled <---")
+	s.Client, err = client.New(basesuite.ChainID, basesuite.Endpoint, client.Option{
+		DefaultAccount: s.DefaultAccount,
+		ForceToUseSpecifiedSpEndpointForDownloadOnly: s.PrimarySP.Endpoint,
+	})
+	s.Require().NoError(err)
+
+	s.T().Log("---> get object with ForceToUseSpecifiedSpEndpointForDownloadOnly <---")
+	objectContent, _, err := s.Client.GetObject(s.ClientContext, bucketName, objectName, types.GetObjectOptions{})
+	if err != nil {
+		fmt.Printf("error: %v", err)
+		quota2, _ := s.Client.GetBucketReadQuota(s.ClientContext, bucketName)
+		fmt.Printf("quota: %v", quota2)
+	}
+	objectBytes, err := io.ReadAll(objectContent)
+	s.Require().NoError(err)
+	s.Require().Equal(objectBytes, buffer.Bytes())
+	s.Require().NoError(err)
+}

--- a/types/option.go
+++ b/types/option.go
@@ -225,6 +225,7 @@ type GetObjectOptions struct {
 	Range            string `url:"-" header:"Range,omitempty"` // Range support for downloading partial data.
 	SupportResumable bool   // SupportResumable support resumable download. Resumable downloads refer to the capability of resuming interrupted or incomplete downloads from the point where they were paused or disrupted.
 	PartSize         uint64 // PartSize indicate the resumable download's part size, download a large file in multiple parts. The part size is an integer multiple of the segment size.
+	Endpoint         string // Endpoint indicates the endpoint of sp
 }
 
 // GetChallengeInfoOptions contains the options for querying challenge data.

--- a/types/option.go
+++ b/types/option.go
@@ -225,7 +225,6 @@ type GetObjectOptions struct {
 	Range            string `url:"-" header:"Range,omitempty"` // Range support for downloading partial data.
 	SupportResumable bool   // SupportResumable support resumable download. Resumable downloads refer to the capability of resuming interrupted or incomplete downloads from the point where they were paused or disrupted.
 	PartSize         uint64 // PartSize indicate the resumable download's part size, download a large file in multiple parts. The part size is an integer multiple of the segment size.
-	Endpoint         string // Endpoint indicates the endpoint of sp
 }
 
 // GetChallengeInfoOptions contains the options for querying challenge data.


### PR DESCRIPTION
### Description

Add ForceToUseSpecifiedSpEndpointForDownloadOnly in api client opt to determine if need to refresh SPs. If ForceToUseSpecifiedSpEndpointForDownloadOnly option is set, the client can only make download requests, and can only download from the fixed endpoint. 

### Rationale

Make go-sdk process speed faster.

### Example
N/A 

### Changes

Notable changes:
* api client option
* api client