### PR TITLE
feat: off-chain-auth simplification in go-sdk

### DIFF
--- a/client/api_off_chain_auth.go
+++ b/client/api_off_chain_auth.go
@@ -283,6 +283,9 @@ func (c *Client) DeleteUserPublicKeyV2(spEndpoint string, domain string, publicK
 	stNow := time.Now().UTC()
 	header[httplib.HTTPHeaderExpiryTimestamp] = stNow.Add(time.Second * types.DefaultExpireSeconds).Format(types.Iso8601DateFormatSecond)
 	req, err := http.NewRequest(http.MethodPost, spEndpoint+"/auth/delete_keys_v2", strings.NewReader(strings.Join(publicKeys, ",")))
+	if err != nil {
+		return false, err
+	}
 	for key, value := range header {
 		req.Header.Set(key, value)
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	cosmossdk.io/math v1.0.1
 	github.com/bnb-chain/greenfield v1.4.1-0.20240221082420-50b8ec14277e
-	github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228
+	github.com/bnb-chain/greenfield-common/go v0.0.0-20240228080631-2683b0ee669a
 	github.com/cometbft/cometbft v0.37.2
 	github.com/consensys/gnark-crypto v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.3

--- a/go.sum
+++ b/go.sum
@@ -158,8 +158,8 @@ github.com/bnb-chain/greenfield-cometbft v1.2.0 h1:LTStppZS9WkVj0TfEYKkk5OAQDGfY
 github.com/bnb-chain/greenfield-cometbft v1.2.0/go.mod h1:WVOEZ59UYM2XePQH47/IQfcInspDn8wbRXhFSJrbU1c=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1 h1:XcWulGacHVRiSCx90Q8Y//ajOrLNBQWR/KDB89dy3cU=
 github.com/bnb-chain/greenfield-cometbft-db v0.8.1-alpha.1/go.mod h1:ey1CiK4bYo1RBNJLRiVbYr5CMdSxci9S/AZRINLtppI=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228 h1:WywBaew30hZuqDTOQbkRV3uBg6XHjNIE1s3AXVXbG+8=
-github.com/bnb-chain/greenfield-common/go v0.0.0-20230906132736-eb2f0efea228/go.mod h1:K9jK80fbahciC+FAvrch8Qsbw9ZkvVgjfKsqrzPTAVA=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20240228080631-2683b0ee669a h1:VjUknQkIcqkjYCt1hmfpinM7kToOBuUU+KykrrqFsEM=
+github.com/bnb-chain/greenfield-common/go v0.0.0-20240228080631-2683b0ee669a/go.mod h1:K9jK80fbahciC+FAvrch8Qsbw9ZkvVgjfKsqrzPTAVA=
 github.com/bnb-chain/greenfield-cosmos-sdk v1.4.1-0.20240221065455-ef1f7f0d2659 h1:ytOD5CuSsmV9pe9HXXJEsxiDKxHzOYShSG8s21Yw5Xw=
 github.com/bnb-chain/greenfield-cosmos-sdk v1.4.1-0.20240221065455-ef1f7f0d2659/go.mod h1:XF8U3VN1euzLkIR5xiSNyQSnBabvnD86oz6fgdrpteQ=
 github.com/bnb-chain/greenfield-cosmos-sdk/api v0.0.0-20231129013257-1e407f209b02 h1:cwuShQ+MlvwkfbOz79BRF4aYjgKAuSyugoCtXE8tWgM=
@@ -353,7 +353,6 @@ github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08/go.mod h1:x
 github.com/getkin/kin-openapi v0.53.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/getkin/kin-openapi v0.61.0/go.mod h1:7Yn5whZr5kJi6t+kShccXS8ae1APpYTW6yheSwk8Yi4=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gliderlabs/ssh v0.1.1/go.mod h1:U7qILu1NlMHj9FlMhZLlkCdDnU1DBEAqr0aevW3Awn0=
 github.com/glycerine/go-unsnap-stream v0.0.0-20180323001048-9f0cb55181dd/go.mod h1:/20jfyN9Y5QPEAprSgKAUr+glWDY39ZiUEAYOEv5dsE=


### PR DESCRIPTION
### Description

off-chain-auth simplification

### Rationale

We aim to provide a simplified off-chain-auth implementation.   It will remove the "key nonce" concept in the original off-chain-auth.

In addition, for EdDSA algorithm, we will use the Ed25519 as the EdDSA curve.

see https://github.com/bnb-chain/BEPs/pull/361

### Example
The following example demostrate how to use the new simplified off-chain-auth by using greenfield-go-sdk. 
If you are developing a web-based dAPP, you should use greenfield-js-sdk to integrate the new simplified off-chain-auth
```
package main

import (
	"bytes"
	"context"
	"errors"
	"fmt"
	"io"
	"log"
	"time"

	"github.com/bnb-chain/greenfield-go-sdk/client"
	"github.com/bnb-chain/greenfield-go-sdk/types"
	storageTypes "github.com/bnb-chain/greenfield/x/storage/types"
)

const rpcAddr = "http://localhost:26750"
const chainId = "greenfield_9000-121"
const privateKey = "xxx"
const primarySP = "0xc063647aDB1668bBaD5C5F15cED3cBf163aDED99"
const endpoint = "http://127.0.0.1:9033"
const bucketName = "rzigw4"
const objectName = "2g36fzmd6524"

func main() {
	useOffChainAuthV2()
}

func useOffChainAuthV2() {

	account, err := types.NewAccountFromPrivateKey("test", privateKey)
	log.Println("test account addr is " + account.GetAddress().String())
	if err != nil {
		log.Fatalf("New account from private key error, %v", err)
	}

	cli, err := client.New(chainId, rpcAddr, client.Option{
		DefaultAccount: account,
		OffChainAuthOptionV2: &client.OffChainAuthOptionV2{
			Seed:                 "test_seed",
			Domain:               "https://test.domain.com",
			ShouldRegisterPubKey: true,
		},
	})
	if err != nil {
		log.Fatalf("unable to new greenfield client, %v", err)
	}
	ctx := context.Background()

	log.Println(primarySP)

	// create bucket
	chargedQuota := uint64(100)
	//ChargedQuota: chargedQuota
	_, err = cli.CreateBucket(ctx, bucketName, primarySP, types.CreateBucketOptions{
		ChargedQuota: chargedQuota,
	})
	// head bucket
	bucketInfo, err := cli.HeadBucket(ctx, bucketName)
	log.Println("bucket info:", bucketInfo.String())

	// Create object content
	var buffer bytes.Buffer
	line := `0123456789`
	// objectSize := 1 * 1024 * 1024 * 100 //  1*1024*1024*100 *  10 == 1GB
	objectSize := 1 * 100 //  1*1024*1024*100 *  10 == 1GB
	for i := 0; i < objectSize; i++ {
		buffer.WriteString(fmt.Sprintf("%s", line))
	}

	// create and put object
	txnHash, err := cli.CreateObject(ctx, bucketName, objectName, bytes.NewReader(buffer.Bytes()), types.CreateObjectOptions{
		ContentType: "text/plain",
		Visibility:  storageTypes.VISIBILITY_TYPE_PRIVATE,
	})

	handleErr(err, "CreateObject")
	err = cli.PutObject(ctx, bucketName, objectName, int64(buffer.Len()),
		bytes.NewReader(buffer.Bytes()), types.PutObjectOptions{TxnHash: txnHash})
	handleErr(err, "PutObject")
	log.Printf("object: %s has been uploaded to SP\n", objectName)

	time.Sleep(time.Second * 20)
	waitObjectSeal(cli, bucketName, objectName)

	// list object
	objects, err := cli.ListObjects(ctx, bucketName, types.ListObjectsOptions{
		true, "", "", "/", "", 10, endpoint, "",
	})
	log.Println("list objects result:")
	for _, obj := range objects.Objects {
		i := obj.ObjectInfo
		log.Printf("object: %s, status: %s\n", i.ObjectName, i.ObjectStatus)
	}
	reader, info, err := cli.GetObject(ctx, bucketName, objectName, types.GetObjectOptions{})
	objectBytes, err := io.ReadAll(reader)
	if err != nil {
		log.Fatalf("err is %v", err)
	}
	log.Printf("get object %s successfully, size %d \n", info.ObjectName, info.Size)
	log.Printf("get object %s successfully, content is  %s \n", info.ObjectName, string(objectBytes))

	keys, err := cli.ListUserPublicKeyV2("http://127.0.0.1:9033", "https://test.domain.com")
	if err != nil {
		log.Fatalf("err is %v", err)
	}
	log.Printf("List User Keys result: %s", keys)

	result, err := cli.DeleteUserPublicKeyV2("http://127.0.0.1:9033", "https://test.domain.com", keys)
	if err != nil {
		log.Fatalf("err is %v", err)
	}
	log.Printf("Delete User Keys result: %v", result)

}

func waitObjectSeal(cli client.IClient, bucketName, objectName string) {
	ctx := context.Background()
	// wait for the object to be sealed
	timeout := time.After(15 * time.Second)
	ticker := time.NewTicker(2 * time.Second)

	for {
		select {
		case <-timeout:
			err := errors.New("object not sealed after 15 seconds")
			handleErr(err, "HeadObject")
		case <-ticker.C:
			objectDetail, err := cli.HeadObject(ctx, bucketName, objectName)
			handleErr(err, "HeadObject")
			if objectDetail.ObjectInfo.GetObjectStatus().String() == "OBJECT_STATUS_SEALED" {
				ticker.Stop()
				fmt.Printf("put object %s successfully \n", objectName)
				return
			}
		}
	}
}

func handleErr(err error, funcName string) {
	if err != nil {
		log.Fatalln("fail to " + funcName + ": " + err.Error())
	}
}

```
### Changes

N/A